### PR TITLE
fix: align storage runtime with Copick

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,13 +20,19 @@ env:
 
 jobs:
   portable:
-    name: portable py${{ matrix.python-version }}
+    name: portable py${{ matrix.python_version }} zarr-${{ matrix.zarr_label }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - python_version: "3.14"
+            zarr_label: minimum
+            zarr_spec: "zarr==3.1.6"
+          - python_version: "3.14"
+            zarr_label: latest
+            zarr_spec: "zarr>=3.1.6,<4"
     steps:
       - name: Checkout plugin
         uses: actions/checkout@v7
@@ -53,11 +59,11 @@ jobs:
             LICENSE
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python_version }}
           cache: pip
           cache-dependency-path: tests/requirements-portable.txt
       - name: Install portable test dependencies
-        run: python -m pip install -r tests/requirements-portable.txt
+        run: python -m pip install -r tests/requirements-portable.txt '${{ matrix.zarr_spec }}'
       - name: Run parser, conformance, and complete-store tests
         env:
           OME_NGFF_SPEC_ROOT: ${{ github.workspace }}/.upstream/ngff
@@ -75,7 +81,7 @@ jobs:
         uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: tests/requirements-portable.txt
       - name: Install portable test dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,22 +49,27 @@ PYTHONPATH="tests/stubs:$PWD" \
 python -m pytest -vv --reruns 2 --reruns-delay 5 tests/portable/test_remote_stores.py
 ```
 
-## ChimeraX 1.12 release gate
+## ChimeraX Daily 1.13 release gate
 
-The bundle retains `ChimeraX-Core>=1.7` as its declared compatibility floor. Development, native integration testing, and bundle compilation are performed with ChimeraX 1.12. Point `CHIMERAX_PYTHON` at the Python executable inside that installation; on macOS, for example:
+The Copick-compatible alpha requires `ChimeraX-Core>=1.13.dev202608172052`, Python 3.14, and NumPy 2. Development, native integration testing, and bundle compilation are performed with ChimeraX Daily 1.13. ChimeraX 1.12 is not a supported host because its compiled volume modules use the NumPy 1 ABI and can crash after NumPy 2 is installed.
+
+Point `CHIMERAX_PYTHON` at the Python executable inside the Daily installation; on macOS, for example:
 
 ```bash
-export CHIMERAX_PYTHON=/Applications/ChimeraX-1.12.app/Contents/bin/python3.11
+export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
 ```
 
-Install the bundle's test dependencies into ChimeraX as needed, then run the real suite without the portable stub:
+Install the bundle's test dependencies into ChimeraX as needed, then run the real suite without the portable stub at both supported Zarr endpoints:
 
 ```bash
+"$CHIMERAX_PYTHON" -m pip install -r tests/requirements-portable.txt "zarr==3.1.6"
+PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m pytest -v tests/chimerax
+"$CHIMERAX_PYTHON" -m pip install --upgrade -r tests/requirements-portable.txt "zarr>=3.1.6,<4"
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m pytest -v tests/chimerax
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd "devel build ."
 ```
 
-This exercises the volume hierarchy, time/channel slicing, multiscale grids, labels, and ChimeraX Segmentations integration against the 1.12 APIs.
+This exercises the volume hierarchy, time/channel slicing, multiscale grids, labels, and ChimeraX Segmentations integration against the Daily 1.13 APIs. Publish this line as an alpha until stable ChimeraX 1.13 passes the same gate.
 
 ## Required branch checks
 
@@ -72,9 +77,8 @@ Configure branch protection for `main` to require these jobs:
 
 - `Conventional Commit PR title`
 - `pre-commit checks`
-- `portable py3.11`
-- `portable py3.12`
-- `portable py3.13`
+- `portable py3.14 zarr-minimum`
+- `portable py3.14 zarr-latest`
 - `required EBI remote stores`
 
 Branch-protection settings live in GitHub rather than the repository, so a repository administrator must enable these checks after the workflows have run once.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Contributions are welcome.
 
 ## Installation
 
+> [!IMPORTANT]
+> The Copick-compatible 1.0 alpha requires ChimeraX Daily 1.13 from
+> `2026-08-17` or newer. ChimeraX 1.12 is built against NumPy 1 and is not
+> compatible with Copick's NumPy 2 runtime. This alpha matches Copick's Zarr
+> range at `>=3.1.6,<4`.
+
 ### From the ChimeraX toolshed
 
 Now available on the ChimeraX toolshed! To download and install run this in the ChimeraX command prompt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,13 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 [project]
 name = "ChimeraX-OME-Zarr"
 version = "1.0.0-alpha"
-dynamic = ["classifiers", "requires-python"]
+requires-python = ">=3.14"
+dynamic = ["classifiers"]
 dependencies = [
-    "ChimeraX-Core>=1.7",
+    "ChimeraX-Core>=1.13.dev202608172052",
     "ChimeraX-Segmentations",
-    "zarr>=3.0.10,<3.1",
+    "numpy>=2.0.2",
+    "zarr>=3.1.6,<4",
     "fsspec>=2024.12.0",
     "s3fs>=2024.12.0",
     "smbprotocol",

--- a/src/map_data/store_cache.py
+++ b/src/map_data/store_cache.py
@@ -20,9 +20,9 @@ _MISSING = object()
 
 
 def _byte_request_key(byte_range: Optional[ByteRequest]):
-    if byte_range is None:
-        return None
-    return type(byte_range).__name__, tuple(sorted(vars(byte_range).items()))
+    # Zarr byte requests are immutable value objects. Keep the object itself in
+    # the cache key instead of depending on its internal storage layout.
+    return byte_range
 
 
 class EncodedStoreCache:

--- a/tests/portable/test_store_cache.py
+++ b/tests/portable/test_store_cache.py
@@ -3,8 +3,11 @@
 import asyncio
 from collections import Counter
 
+import fsspec
+import numpy as np
 import zarr
-from zarr.abc.store import RangeByteRequest
+from zarr.abc.store import OffsetByteRequest, RangeByteRequest, SuffixByteRequest
+from zarr.codecs import Shuffle, ZstdCodec
 from zarr.core.buffer import default_buffer_prototype
 
 from src.map_data.store_cache import (
@@ -42,15 +45,22 @@ def test_cached_store_reuses_full_range_and_missing_reads():
     async def read_values():
         full_first = await store.get("payload", prototype)
         full_second = await store.get("payload", prototype)
-        byte_range = RangeByteRequest(1, 4)
-        range_first = await store.get("payload", prototype, byte_range)
-        range_second = await store.get("payload", prototype, byte_range)
+        byte_requests = (
+            (RangeByteRequest(1, 4), b"bcd"),
+            (OffsetByteRequest(2), b"cdef"),
+            (SuffixByteRequest(3), b"def"),
+        )
+        range_values = []
+        for byte_request, expected in byte_requests:
+            first = await store.get("payload", prototype, byte_request)
+            second = await store.get("payload", prototype, byte_request)
+            range_values.append((first, second, expected))
         missing_first = await store.get("missing", prototype)
         missing_second = await store.get("missing", prototype)
         missing_exists = await store.exists("missing")
         partial_values = await store.get_partial_values(
             prototype,
-            [("payload", byte_range), ("missing", None)],
+            [("payload", byte_request) for byte_request, _ in byte_requests] + [("missing", None)],
         )
         many_values = [
             value
@@ -61,8 +71,7 @@ def test_cached_store_reuses_full_range_and_missing_reads():
         return (
             full_first,
             full_second,
-            range_first,
-            range_second,
+            range_values,
             missing_first,
             missing_second,
             missing_exists,
@@ -73,8 +82,7 @@ def test_cached_store_reuses_full_range_and_missing_reads():
     (
         full_first,
         full_second,
-        range_first,
-        range_second,
+        range_values,
         missing_first,
         missing_second,
         missing_exists,
@@ -83,16 +91,74 @@ def test_cached_store_reuses_full_range_and_missing_reads():
     ) = asyncio.run(read_values())
 
     assert full_first.to_bytes() == full_second.to_bytes() == b"abcdef"
-    assert range_first.to_bytes() == range_second.to_bytes() == b"bcd"
+    for first, second, expected in range_values:
+        assert first.to_bytes() == second.to_bytes() == expected
     assert missing_first is missing_second is None
     assert missing_exists is False
-    assert partial_values[0].to_bytes() == b"bcd"
-    assert partial_values[1] is None
+    assert [value.to_bytes() for value in partial_values[:-1]] == [b"bcd", b"cdef", b"def"]
+    assert partial_values[-1] is None
     assert many_values[0].to_bytes() == b"abcdef"
     assert many_values[1] is None
-    assert sum(counting_store.gets.values()) == 3
-    assert cache.entry_count == 3
-    assert cache.used == 10
+    assert sum(counting_store.gets.values()) == 5
+    assert cache.entry_count == 5
+    assert cache.used == 17
+
+
+def test_cached_store_reads_copick_style_multichunk_shard(tmp_path):
+    path = tmp_path / "copick-style.zarr"
+    expected = np.arange(8**3, dtype=np.float32).reshape((8, 8, 8))
+    root = zarr.open_group(str(path), mode="w", zarr_format=3)
+    array = root.create_array(
+        "0",
+        shape=expected.shape,
+        chunks=(2, 2, 2),
+        shards=(8, 8, 8),
+        dtype=expected.dtype,
+        dimension_names=("z", "y", "x"),
+        compressors=(Shuffle(elementsize=expected.dtype.itemsize), ZstdCodec(level=3)),
+        chunk_key_encoding={"name": "v2", "separator": "/"},
+    )
+    array[:] = expected
+
+    filesystem = fsspec.filesystem("file", asynchronous=True)
+    source = zarr.storage.FsspecStore.from_mapper(filesystem.get_mapper(str(path)), read_only=True)
+    counting_store = CountingStore(source)
+    cache = EncodedStoreCache(MEBIBYTE)
+    group = zarr.open_group(store=CachedStore(counting_store, cache), mode="r")
+    selection = np.s_[2:6, 2:6, 2:6]
+
+    np.testing.assert_array_equal(group["0"][selection], expected[selection])
+    reads_after_first_slice = sum(counting_store.gets.values())
+    np.testing.assert_array_equal(group["0"][selection], expected[selection])
+
+    assert reads_after_first_slice > 0
+    assert sum(counting_store.gets.values()) == reads_after_first_slice
+
+
+def test_encoded_store_cache_invalidates_keys_prefixes_and_namespaces():
+    cache = EncodedStoreCache(1024)
+    namespace = object()
+    other_namespace = object()
+    byte_request = RangeByteRequest(1, 4)
+    root_metadata = (namespace, "root/zarr.json", None)
+    chunk_range = (namespace, "root/0/0/0", byte_request)
+    unrelated = (namespace, "other/zarr.json", None)
+    other_store = (other_namespace, "root/0/0/0", byte_request)
+    for cache_key in (root_metadata, chunk_range, unrelated, other_store):
+        cache.store(cache_key, b"value")
+
+    cache.invalidate_key(namespace, "root/zarr.json")
+    assert cache.lookup(root_metadata) == (False, None)
+    assert cache.lookup(chunk_range) == (True, b"value")
+
+    cache.invalidate_prefix(namespace, "root/")
+    assert cache.lookup(chunk_range) == (False, None)
+    assert cache.lookup(unrelated) == (True, b"value")
+    assert cache.lookup(other_store) == (True, b"value")
+
+    cache.invalidate_namespace(namespace)
+    assert cache.lookup(unrelated) == (False, None)
+    assert cache.lookup(other_store) == (True, b"value")
 
 
 def test_encoded_store_cache_evicts_lru_and_skips_oversized_values():

--- a/tests/requirements-portable.txt
+++ b/tests/requirements-portable.txt
@@ -1,5 +1,5 @@
 fsspec[http]>=2024.12.0
-numpy>=1.26
+numpy>=2.0.2
 pytest>=8
 pytest-rerunfailures>=14
-zarr>=3.0.10,<3.1
+zarr>=3.1.6,<4


### PR DESCRIPTION

## Summary

- align the NumPy and Zarr runtime with the Copick 2 alpha
- target ChimeraX Daily 1.13 and Python 3.14 for NumPy 2 compatibility
- make encoded-store cache keys compatible with current Zarr byte requests
- add Copick-style sharded-read and cache invalidation regressions
- test both the minimum and latest supported Zarr 3 releases in CI

## Validation

- `pre-commit run --all-files`
- `action-validator .github/workflows/tests.yml`
- portable suite: 27 passed with Zarr 3.1.6 and 27 passed with Zarr 3.3.0
- ChimeraX Daily native suite: 64 passed at both Zarr endpoints
- required EBI remote tests: 3 passed at both Zarr endpoints
- built the bundle and opened real Copick tomogram, density, and segmentation stores in ChimeraX Daily
