### PR TITLE
build: remove unused setuptools-scm requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=45"]
 
 [project]
 name = "ChimeraX-OME-Zarr"


### PR DESCRIPTION

## Summary

- remove the unused `setuptools_scm` build requirement
- allow ChimeraX Daily to build the bundle without an extra package installed
- retain the existing static project version

## Validation

- built `dist/chimerax_ome_zarr-1.0.0a0-py3-none-any.whl` with ChimeraX Daily
- repository pre-commit hooks passed
- `git diff --check`
