### PR TITLE
feat: add Lodstone progressive streaming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Install the Lodstone PR and this development bundle into ChimeraX Daily:
 ```bash
 export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
 "$CHIMERAX_PYTHON" -m pip install --no-deps --force-reinstall \
-  git+https://github.com/kephale/lodstone.git@e71536d4bc16b15c6a3eb5d85387e86630f318d4
+  git+https://github.com/kephale/lodstone.git@157a23b27b00d1f239c7ceb3a75bd0c3c93ff197
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit \
   --cmd "devel build ."
 "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Install the Lodstone PR and this development bundle into ChimeraX Daily:
 ```bash
 export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
 "$CHIMERAX_PYTHON" -m pip install --no-deps --force-reinstall \
-  git+https://github.com/kephale/lodstone.git@3656fc1ebf85680c93b3e4b3f3d3b3a3e2d62981
+  git+https://github.com/kephale/lodstone.git@1f11e018e0529bac31a0e0b77d0a24a1815987e5
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit \
   --cmd "devel build ."
 "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Install the Lodstone PR and this development bundle into ChimeraX Daily:
 ```bash
 export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
 "$CHIMERAX_PYTHON" -m pip install --no-deps --force-reinstall \
-  git+https://github.com/kephale/lodstone.git@1f11e018e0529bac31a0e0b77d0a24a1815987e5
+  git+https://github.com/kephale/lodstone.git@a10a186297573644e8ad69288cd50a3f4d01c607
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit \
   --cmd "devel build ."
 "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,12 +73,13 @@ This exercises the volume hierarchy, time/channel slicing, multiscale grids, lab
 
 ## Interactive Lodstone streaming
 
-Install the Lodstone PR and this development bundle into ChimeraX Daily:
+Install the released Lodstone alpha and this development bundle into ChimeraX
+Daily:
 
 ```bash
 export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
 "$CHIMERAX_PYTHON" -m pip install --no-deps --force-reinstall \
-  git+https://github.com/kephale/lodstone.git@97a8cc015d803397409cdb2008e64ceeeef987bf
+  lodstone==0.1.0a0
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit \
   --cmd "devel build ."
 "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,37 @@ PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd "deve
 
 This exercises the volume hierarchy, time/channel slicing, multiscale grids, labels, and ChimeraX Segmentations integration against the Daily 1.13 APIs. Publish this line as an alpha until stable ChimeraX 1.13 passes the same gate.
 
+## Interactive Lodstone streaming
+
+Install the Lodstone PR and this development bundle into ChimeraX Daily:
+
+```bash
+export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
+"$CHIMERAX_PYTHON" -m pip install --no-deps --force-reinstall \
+  git+https://github.com/kephale/lodstone.git@3656fc1ebf85680c93b3e4b3f3d3b3a3e2d62981
+PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit \
+  --cmd "devel build ."
+"$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd \
+  "toolshed install $PWD/dist/chimerax_ome_zarr-1.0.0a1-py3-none-any.whl noDeps true reinstall true"
+```
+
+Launch the graphical application:
+
+```bash
+open -na /Applications/ChimeraX_Daily.app
+```
+
+Then enter this in ChimeraX's command line, after its main window is ready:
+
+```chimerax
+open ngff:https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr streaming true
+```
+
+Rotate and zoom the volume while watching the ChimeraX log. Each camera change
+starts a new Lodstone generation; coarse data should remain visible while fine
+resident chunks replace it. Closing the top-level image model must stop all
+streams without a later callback traceback.
+
 ## Required branch checks
 
 Configure branch protection for `main` to require these jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Install the Lodstone PR and this development bundle into ChimeraX Daily:
 ```bash
 export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
 "$CHIMERAX_PYTHON" -m pip install --no-deps --force-reinstall \
-  git+https://github.com/kephale/lodstone.git@a10a186297573644e8ad69288cd50a3f4d01c607
+  git+https://github.com/kephale/lodstone.git@97fae3ea957ba23a9f39d9a4470a0248a7d7fee1
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit \
   --cmd "devel build ."
 "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Install the Lodstone PR and this development bundle into ChimeraX Daily:
 ```bash
 export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
 "$CHIMERAX_PYTHON" -m pip install --no-deps --force-reinstall \
-  git+https://github.com/kephale/lodstone.git@157a23b27b00d1f239c7ceb3a75bd0c3c93ff197
+  git+https://github.com/kephale/lodstone.git@97a8cc015d803397409cdb2008e64ceeeef987bf
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit \
   --cmd "devel build ."
 "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Install the Lodstone PR and this development bundle into ChimeraX Daily:
 ```bash
 export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
 "$CHIMERAX_PYTHON" -m pip install --no-deps --force-reinstall \
-  git+https://github.com/kephale/lodstone.git@97fae3ea957ba23a9f39d9a4470a0248a7d7fee1
+  git+https://github.com/kephale/lodstone.git@e71536d4bc16b15c6a3eb5d85387e86630f318d4
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit \
   --cmd "devel build ."
 "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd \

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@157a23b27b00d1f239c7ceb3a75bd0c3c93ff197
+  git+https://github.com/kephale/lodstone.git@c54af35379a3a4c33cafae30eca1abd6c89bc323
 ```
 
 ```chimerax
@@ -86,9 +86,11 @@ open ngff:https://example.org/image.zarr streaming true
 
 Streaming progressively fills bounded ChimeraX array-backed volumes, keeps unloaded fine chunks filled from the best
 available coarse level, replans after camera changes, and publishes each complete pyramid phase through ChimeraX's
-normal volume-update path. Camera replanning uses a short trailing debounce and LOD hysteresis, while refinement skips
-intermediate pyramid levels to reach the camera-selected target sooner. Explicit `scales`, associated `labels`, and
-time series are not combined with this mode yet.
+normal volume-update path. Target-confirmed residency and shared in-flight reads preserve overlap across replans.
+Completed snapshots enter per-channel back buffers; all channels switch together before the previous immutable fronts
+are retired. Camera replanning uses a short trailing debounce and LOD hysteresis, while refinement skips intermediate
+pyramid levels to reach the camera-selected target sooner. Explicit `scales`, associated `labels`, and time series are
+not combined with this mode yet.
 
 For 3D time series, the plugin uses idle time after a frame is drawn to preload future timepoints at the same region,
 sampling step, channel, and resolution level. By default it fills an adaptive, memory-bounded buffer. To limit the

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@f001e3fe9c650bb0717bdfe6d4cd1874b6325a69
+  git+https://github.com/kephale/lodstone.git@3656fc1ebf85680c93b3e4b3f3d3b3a3e2d62981
 ```
 
 ```chimerax
@@ -85,8 +85,9 @@ open ngff:https://example.org/image.zarr streaming true
 ```
 
 Streaming progressively fills bounded ChimeraX array-backed volumes, patches initialized 3D textures as blocks
-arrive, replans after camera changes, and switches pyramid levels automatically. Explicit `scales` and associated
-`labels` are not combined with this mode yet.
+arrive, keeps unloaded fine chunks filled from the best available coarse level, replans after camera changes, and
+switches pyramid levels automatically. Explicit `scales`, associated `labels`, and time series are not combined with
+this mode yet.
 
 For 3D time series, the plugin uses idle time after a frame is drawn to preload future timepoints at the same region,
 sampling step, channel, and resolution level. By default it fills an adaptive, memory-bounded buffer. To limit the

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ open ngff:s3://bucket-name/path/to/file.zarr
 open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 ```
 
+**To stream camera-selected multiscale chunks with Lodstone:**
+
+```bash
+/Applications/ChimeraX_Daily.app/Contents/bin/pip install \
+  git+https://github.com/kephale/lodstone.git@e2b9c18be0c8d8c2681253c8d27dfddfdcc747ad
+```
+
+```chimerax
+open ngff:https://example.org/image.zarr streaming true
+```
+
+Streaming progressively fills ChimeraX array-backed volumes, replans after camera changes, and switches pyramid
+levels automatically. Explicit `scales` and associated `labels` are not combined with this mode yet.
+
 For 3D time series, the plugin uses idle time after a frame is drawn to preload future timepoints at the same region,
 sampling step, channel, and resolution level. By default it fills an adaptive, memory-bounded buffer. To limit the
 buffer to a fixed number of future timepoints, or disable temporal read-ahead entirely:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@97fae3ea957ba23a9f39d9a4470a0248a7d7fee1
+  git+https://github.com/kephale/lodstone.git@e71536d4bc16b15c6a3eb5d85387e86630f318d4
 ```
 
 ```chimerax

--- a/README.md
+++ b/README.md
@@ -84,9 +84,11 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 open ngff:https://example.org/image.zarr streaming true
 ```
 
-Streaming progressively fills bounded ChimeraX array-backed volumes, keeps unloaded fine chunks filled from the best
-available coarse level, replans after camera changes, and publishes each complete pyramid phase through ChimeraX's
-normal volume-update path. Target-confirmed residency and shared in-flight reads preserve overlap across replans.
+Streaming progressively fills bounded ChimeraX array-backed volumes and keeps a full coarsest-level context volume
+visible beneath the camera-focused detail window. The occupied detail footprint is masked from the coarse volume to
+avoid double rendering. User-adjusted contrast, colors, brightness, and transparency are shared by both clipmap levels
+and retained when snapshots are replaced. Camera changes trigger bounded replanning, while target-confirmed residency
+and shared in-flight reads preserve overlap across replans.
 Completed snapshots enter per-channel back buffers; all channels switch together before the previous immutable fronts
 are retired. Camera replanning uses a short trailing debounce and LOD hysteresis, while refinement skips intermediate
 pyramid levels to reach the camera-selected target sooner. Explicit `scales`, associated `labels`, and time series are

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@97a8cc015d803397409cdb2008e64ceeeef987bf
+  lodstone==0.1.0a0
 ```
 
 ```chimerax

--- a/README.md
+++ b/README.md
@@ -77,17 +77,16 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@3656fc1ebf85680c93b3e4b3f3d3b3a3e2d62981
+  git+https://github.com/kephale/lodstone.git@1f11e018e0529bac31a0e0b77d0a24a1815987e5
 ```
 
 ```chimerax
 open ngff:https://example.org/image.zarr streaming true
 ```
 
-Streaming progressively fills bounded ChimeraX array-backed volumes, patches initialized 3D textures as blocks
-arrive, keeps unloaded fine chunks filled from the best available coarse level, replans after camera changes, and
-switches pyramid levels automatically. Explicit `scales`, associated `labels`, and time series are not combined with
-this mode yet.
+Streaming progressively fills bounded ChimeraX array-backed volumes, keeps unloaded fine chunks filled from the best
+available coarse level, replans after camera changes, and publishes each complete pyramid phase through ChimeraX's
+normal volume-update path. Explicit `scales`, associated `labels`, and time series are not combined with this mode yet.
 
 For 3D time series, the plugin uses idle time after a frame is drawn to preload future timepoints at the same region,
 sampling step, channel, and resolution level. By default it fills an adaptive, memory-bounded buffer. To limit the

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@c54af35379a3a4c33cafae30eca1abd6c89bc323
+  git+https://github.com/kephale/lodstone.git@97a8cc015d803397409cdb2008e64ceeeef987bf
 ```
 
 ```chimerax

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@1f11e018e0529bac31a0e0b77d0a24a1815987e5
+  git+https://github.com/kephale/lodstone.git@a10a186297573644e8ad69288cd50a3f4d01c607
 ```
 
 ```chimerax
@@ -86,7 +86,9 @@ open ngff:https://example.org/image.zarr streaming true
 
 Streaming progressively fills bounded ChimeraX array-backed volumes, keeps unloaded fine chunks filled from the best
 available coarse level, replans after camera changes, and publishes each complete pyramid phase through ChimeraX's
-normal volume-update path. Explicit `scales`, associated `labels`, and time series are not combined with this mode yet.
+normal volume-update path. Camera replanning uses a short trailing debounce and LOD hysteresis, while refinement skips
+intermediate pyramid levels to reach the camera-selected target sooner. Explicit `scales`, associated `labels`, and
+time series are not combined with this mode yet.
 
 For 3D time series, the plugin uses idle time after a frame is drawn to preload future timepoints at the same region,
 sampling step, channel, and resolution level. By default it fills an adaptive, memory-bounded buffer. To limit the

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@e71536d4bc16b15c6a3eb5d85387e86630f318d4
+  git+https://github.com/kephale/lodstone.git@157a23b27b00d1f239c7ceb3a75bd0c3c93ff197
 ```
 
 ```chimerax

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@a10a186297573644e8ad69288cd50a3f4d01c607
+  git+https://github.com/kephale/lodstone.git@97fae3ea957ba23a9f39d9a4470a0248a7d7fee1
 ```
 
 ```chimerax

--- a/README.md
+++ b/README.md
@@ -77,15 +77,16 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  git+https://github.com/kephale/lodstone.git@e2b9c18be0c8d8c2681253c8d27dfddfdcc747ad
+  git+https://github.com/kephale/lodstone.git@f001e3fe9c650bb0717bdfe6d4cd1874b6325a69
 ```
 
 ```chimerax
 open ngff:https://example.org/image.zarr streaming true
 ```
 
-Streaming progressively fills ChimeraX array-backed volumes, replans after camera changes, and switches pyramid
-levels automatically. Explicit `scales` and associated `labels` are not combined with this mode yet.
+Streaming progressively fills bounded ChimeraX array-backed volumes, patches initialized 3D textures as blocks
+arrive, replans after camera changes, and switches pyramid levels automatically. Explicit `scales` and associated
+`labels` are not combined with this mode yet.
 
 For 3D time series, the plugin uses idle time after a frame is drawn to preload future timepoints at the same region,
 sampling step, channel, and resolution level. By default it fills an adaptive, memory-bounded buffer. To limit the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@3b773af4bb8089671b352cfa83aab9a3d69f4b7e",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@c8e5f88dcd5ad175fb6e2569dcc1aa672c9099f4",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@1f11e018e0529bac31a0e0b77d0a24a1815987e5",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@a10a186297573644e8ad69288cd50a3f4d01c607",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@f001e3fe9c650bb0717bdfe6d4cd1874b6325a69",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@3656fc1ebf85680c93b3e4b3f3d3b3a3e2d62981",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ Repository = "https://github.com/uermel/chimerax-ome-zarr.git"
 Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
+streaming = [
+    "lodstone @ git+https://github.com/kephale/lodstone.git@cf917d0527c0646fe36f4dc4476272b1cf9be64b",
+]
 dev = [
     "black",
     "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@3656fc1ebf85680c93b3e4b3f3d3b3a3e2d62981",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@1f11e018e0529bac31a0e0b77d0a24a1815987e5",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@c54af35379a3a4c33cafae30eca1abd6c89bc323",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@8416885e3af802d2c7afb3c624e411d36d76c201",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@a10a186297573644e8ad69288cd50a3f4d01c607",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@97fae3ea957ba23a9f39d9a4470a0248a7d7fee1",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@cf917d0527c0646fe36f4dc4476272b1cf9be64b",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@f001e3fe9c650bb0717bdfe6d4cd1874b6325a69",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@e71536d4bc16b15c6a3eb5d85387e86630f318d4",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@157a23b27b00d1f239c7ceb3a75bd0c3c93ff197",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@c8e5f88dcd5ad175fb6e2569dcc1aa672c9099f4",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@97a8cc015d803397409cdb2008e64ceeeef987bf",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@8416885e3af802d2c7afb3c624e411d36d76c201",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@3b773af4bb8089671b352cfa83aab9a3d69f4b7e",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@157a23b27b00d1f239c7ceb3a75bd0c3c93ff197",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@c54af35379a3a4c33cafae30eca1abd6c89bc323",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@97fae3ea957ba23a9f39d9a4470a0248a7d7fee1",
+    "lodstone @ git+https://github.com/kephale/lodstone.git@e71536d4bc16b15c6a3eb5d85387e86630f318d4",
 ]
 dev = [
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone @ git+https://github.com/kephale/lodstone.git@97a8cc015d803397409cdb2008e64ceeeef987bf",
+    "lodstone==0.1.0a0",
 ]
 dev = [
     "black",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -21,6 +21,11 @@ class _MyAPI(BundleAPI):
 
     @staticmethod
     def get_class(name):
+        if name == "LodstoneZarrModel":
+            from .lodstone_adapter import LodstoneZarrModel
+
+            return LodstoneZarrModel
+
         from .map_data.labels import OMELabelIndexGrid, OMELabelMaskGrid, OMEZarrSegmentation
         from .map_data.zarr_grid import WrappedZarrGrid, ZarrGrid, ZarrModel
 

--- a/src/docs/user/commands/open.html
+++ b/src/docs/user/commands/open.html
@@ -9,6 +9,7 @@
     <h3 class="usage"><a href="usageconventions.html">Usage</a>:
       <b>open</b> (  <i>filename.zarr</i> | <i>ngff:[<b>protocol</b>:]URL.zarr</i>  )</a>
       [ <i>scales scale1,scale2,...</i> ] [ <i>labels true|false</i> ] [ <i>readAhead N</i> ]
+      [ <i>streaming true|false</i> ]
     </h3>
     <p> OME-Zarr files can be opened with the <b>open</b>-command similar to any other ChimeraX-supported file. When
         appending the "ngff:"-prefix to the URL and including a protocol prefix (such as "s3://" or "smb://") allow
@@ -28,6 +29,9 @@
         drawn. Set <b>readAhead</b> to a nonnegative number to limit the number of future timepoints, or 0 to disable
         it. Read-ahead is best-effort and does not delay the built-in Map Series player. Plane display does not trigger
         temporal reads.<br>
+        Set <b>streaming true</b> to use Lodstone for camera-driven progressive chunk loading and automatic pyramid
+        selection. This mode currently applies to direct image groups and cannot be combined with explicit
+        <b>scales</b> or <b>labels</b>.<br>
         Editing an imported mask updates the in-session label map but does not write to the OME-Zarr store.<br>
       <br>
       Examples: </p>
@@ -35,6 +39,7 @@
     <blockquote> <b>open ngff:s3://bucket/path/to/image.zarr</b> - open an OME-Zarr from AWS S3</blockquote>
     <blockquote> <b>open ngff:s3://bucket/path/to/image.zarr scales 1,2</b> - open two multiscale levels of an OME-Zarr from AWS S3</blockquote>
     <blockquote> <b>open ngff:https://example.org/image.zarr readAhead 3</b> - buffer at most three future timepoints</blockquote>
+    <blockquote> <b>open ngff:https://example.org/image.zarr streaming true</b> - progressively stream the camera-selected level</blockquote>
     <blockquote> <b>open /path/to/image.zarr labels true</b> - open an image with associated labels</blockquote>
     <p></p>
     <hr>

--- a/src/docs/user/commands/open.html
+++ b/src/docs/user/commands/open.html
@@ -30,7 +30,9 @@
         it. Read-ahead is best-effort and does not delay the built-in Map Series player. Plane display does not trigger
         temporal reads.<br>
         Set <b>streaming true</b> to use Lodstone for camera-driven progressive chunk loading and automatic pyramid
-        selection. For a time series, <b>time</b> selects the single zero-based timepoint to stream.
+        selection. A full coarse context remains visible beneath the focused detail window, and display contrast
+        settings persist when streamed snapshots are replaced. For a time series, <b>time</b> selects the single
+        zero-based timepoint to stream.
         This mode currently applies to direct image groups and cannot be combined with explicit
         <b>scales</b> or <b>labels</b>.<br>
         Editing an imported mask updates the in-session label map but does not write to the OME-Zarr store.<br>

--- a/src/docs/user/commands/open.html
+++ b/src/docs/user/commands/open.html
@@ -9,7 +9,7 @@
     <h3 class="usage"><a href="usageconventions.html">Usage</a>:
       <b>open</b> (  <i>filename.zarr</i> | <i>ngff:[<b>protocol</b>:]URL.zarr</i>  )</a>
       [ <i>scales scale1,scale2,...</i> ] [ <i>labels true|false</i> ] [ <i>readAhead N</i> ]
-      [ <i>streaming true|false</i> ]
+      [ <i>streaming true|false</i> ] [ <i>time index</i> ]
     </h3>
     <p> OME-Zarr files can be opened with the <b>open</b>-command similar to any other ChimeraX-supported file. When
         appending the "ngff:"-prefix to the URL and including a protocol prefix (such as "s3://" or "smb://") allow
@@ -30,7 +30,8 @@
         it. Read-ahead is best-effort and does not delay the built-in Map Series player. Plane display does not trigger
         temporal reads.<br>
         Set <b>streaming true</b> to use Lodstone for camera-driven progressive chunk loading and automatic pyramid
-        selection. This mode currently applies to direct image groups and cannot be combined with explicit
+        selection. For a time series, <b>time</b> selects the single zero-based timepoint to stream.
+        This mode currently applies to direct image groups and cannot be combined with explicit
         <b>scales</b> or <b>labels</b>.<br>
         Editing an imported mask updates the in-session label map but does not write to the OME-Zarr store.<br>
       <br>

--- a/src/info.py
+++ b/src/info.py
@@ -37,6 +37,7 @@ class OMEZarrOpenerInfo(OpenerInfo):
             "labels": BoolArg,
             "read_ahead": NonNegativeIntArg,
             "streaming": BoolArg,
+            "time": NonNegativeIntArg,
         }
 
 
@@ -67,4 +68,5 @@ class NGFFFetcherInfo(FetcherInfo):
             "labels": BoolArg,
             "read_ahead": NonNegativeIntArg,
             "streaming": BoolArg,
+            "time": NonNegativeIntArg,
         }

--- a/src/info.py
+++ b/src/info.py
@@ -32,7 +32,12 @@ class OMEZarrOpenerInfo(OpenerInfo):
     def open_args(self) -> Dict[str, Any]:
         from chimerax.core.commands import BoolArg, ListOf, NonNegativeIntArg, StringArg
 
-        return {"scales": ListOf(StringArg), "labels": BoolArg, "read_ahead": NonNegativeIntArg}
+        return {
+            "scales": ListOf(StringArg),
+            "labels": BoolArg,
+            "read_ahead": NonNegativeIntArg,
+            "streaming": BoolArg,
+        }
 
 
 class NGFFFetcherInfo(FetcherInfo):
@@ -57,4 +62,9 @@ class NGFFFetcherInfo(FetcherInfo):
     def fetch_args(self) -> Dict[str, Any]:
         from chimerax.core.commands import BoolArg, ListOf, NonNegativeIntArg, StringArg
 
-        return {"scales": ListOf(StringArg), "labels": BoolArg, "read_ahead": NonNegativeIntArg}
+        return {
+            "scales": ListOf(StringArg),
+            "labels": BoolArg,
+            "read_ahead": NonNegativeIntArg,
+            "streaming": BoolArg,
+        }

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -29,85 +29,6 @@ from .map_data.zarr_grid import _apply_omero_display
 DEFAULT_GPU_BUDGET = 256 * 1024**2
 
 
-def _upload_texture_3d(texture, data: np.ndarray, offset_zyx) -> None:
-    """Upload one scalar ZYX subarray into an initialized ChimeraX texture."""
-
-    from chimerax.graphics import opengl
-
-    data = np.ascontiguousarray(data)
-    texture_format, _internal_format, texture_dtype, _components = texture.texture_format(data)
-    z_offset, y_offset, x_offset = offset_zyx
-    depth, height, width = data.shape
-    gl = opengl.GL
-    target = texture.gl_target
-    gl.glBindTexture(target, texture.id)
-    try:
-        gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
-        gl.glTexSubImage3D(
-            target,
-            0,
-            x_offset,
-            y_offset,
-            z_offset,
-            width,
-            height,
-            depth,
-            texture_format,
-            texture_dtype,
-            data,
-        )
-    finally:
-        gl.glBindTexture(target, 0)
-
-
-def _patch_volume_texture(volume, buffer, window, regions, displayed_axes) -> bool:
-    """Patch an existing scalar 3D texture, returning false when unsafe."""
-
-    if buffer.ndim != 3:
-        return False
-    image = getattr(volume, "_image", None)
-    if image is None or getattr(image, "deleted", False):
-        return False
-    options = getattr(image, "_rendering_options", None)
-    if options is None or not options.colormap_on_gpu or getattr(image, "_blend_image", None) is not None:
-        return False
-
-    if getattr(image, "_p_mode", None) == "rays":
-        drawing = getattr(image, "_volume_raycast_drawing", None)
-    elif getattr(image, "_use_3d_texture", False):
-        drawing = getattr(image, "_planes_3d", None)
-    else:
-        return False
-    texture = getattr(drawing, "texture", None)
-    if (
-        texture is None
-        or texture.id is None
-        or texture.dimension != 3
-        or texture.data is not None
-        or texture._array_shape != tuple(buffer.shape)
-        or texture._numpy_dtype != buffer.dtype
-    ):
-        return False
-
-    patches = []
-    for item in regions:
-        region = getattr(item, "region", item)
-        starts = tuple(region.start[axis] - window.region.start[axis] for axis in displayed_axes)
-        stops = tuple(region.stop[axis] - window.region.start[axis] for axis in displayed_axes)
-        if any(
-            start < 0 or stop > size or stop <= start
-            for start, stop, size in zip(starts, stops, buffer.shape, strict=True)
-        ):
-            return False
-        patch = buffer[tuple(slice(start, stop) for start, stop in zip(starts, stops, strict=True))]
-        patches.append((patch, starts))
-
-    volume.session.main_view.render.make_current()
-    for patch, offset in patches:
-        _upload_texture_3d(texture, patch, offset)
-    return True
-
-
 def _homogeneous_place(place) -> np.ndarray:
     matrix = np.eye(4, dtype=np.float64)
     matrix[:3, :] = place.matrix
@@ -206,6 +127,8 @@ class ChimeraXVolumeTarget:
         self.resident = ResidentArrays(source.pyramid, dtypes=dtypes, compose=True)
         self.resources = {}
         self.current_window = None
+        self._published_windows = set()
+        self._deferred_retired = set()
         self._value_ranges = {}
 
         # Establish bounds before the first camera-driven plan. This lets the
@@ -239,38 +162,36 @@ class ChimeraXVolumeTarget:
             elif self._bounds_resource is not None:
                 self._bounds_resource[2].display = self._channel_active()
 
-    def stage(self, updates: Sequence[Update]):
-        """Write, convert, and compose resident arrays off the graphics thread."""
-
-        return self.resident.apply(updates)
-
-    def apply(self, staged) -> None:
-        if staged and isinstance(staged[0], Update):
-            staged = self.stage(staged)
-        changes = staged
+    def apply(self, updates: Sequence[Update]) -> None:
+        # ResidentArrays is mutable target state. Keep its writes behind
+        # Stream's stale-generation check on the ChimeraX thread.
+        changes = self.resident.apply(updates)
         for change in changes:
-            buffer, grid, volume = self._ensure_window(change.window)
+            buffer, _grid, _volume = self._ensure_window(change.window)
             for region in change.regions:
                 self._observe_values(
                     change.window,
                     self._buffer_region(buffer, change.window, region),
                 )
-            self._update_thresholds(change.window)
-            if not _patch_volume_texture(
-                volume,
-                buffer,
-                change.window,
-                change.regions,
-                self.displayed_axes,
-            ):
-                grid.values_changed()
 
     def phase_complete(self, view, plan, phase: int) -> None:
         levels = {tile.level for tile in plan.desired if tile.phase == phase}
         for level in sorted(levels):
             window = self.resident.windows.get(level)
             if window is not None and window.key_regions:
-                self._show_window(window)
+                buffer, _grid, old_volume = self._ensure_window(window)
+                self._delete_volume(old_volume)
+                _snapshot, grid, volume = self._create_volume(
+                    buffer.copy(),
+                    window.level,
+                    tuple(window.region.start[axis] for axis in self.displayed_axes),
+                )
+                # Keep observing Lodstone's mutable resident array, but expose
+                # only the completed immutable snapshot to ChimeraX.
+                self.resources[window] = (buffer, grid, volume)
+                self._link_channel_volumes(window.level)
+                self._update_thresholds(window)
+                self._schedule_snapshot_publish(window, volume)
 
     def _maximum_texture_extent(self):
         render = getattr(getattr(self.session, "main_view", None), "render", None)
@@ -297,11 +218,19 @@ class ChimeraXVolumeTarget:
 
     def complete(self, view, plan) -> None:
         transition = self.resident.complete(plan)
+        for window in transition.retired:
+            if window is self.current_window:
+                self._deferred_retired.add(window)
+            else:
+                self._retire_window(window)
         target = self.resident.active.get(plan.target_level)
         if target is not None:
-            self._show_window(target)
-        for window in transition.retired:
-            self._retire_window(window)
+            presenter = getattr(self.owner, "present_lodstone_level", None)
+            if presenter is None:
+                self._show_window(target)
+                self._flush_deferred_retired()
+            else:
+                presenter(target.level)
         if self._bounds_resource is not None:
             self._delete_volume(self._bounds_resource[2])
             self._bounds_resource = None
@@ -324,15 +253,18 @@ class ChimeraXVolumeTarget:
         full_shape = tuple(info.shape[axis] for axis in self.displayed_axes)
         shape = tuple(min(size, 2) for size in full_shape)
         step_scale = tuple(
-            (full_size - 1) / (size - 1) if size > 1 else 1.0 for full_size, size in zip(full_shape, shape, strict=True)
+            (full_size - 1) / (size - 1) if size > 1 else 1.0
+            for full_size, size in zip(full_shape, shape, strict=True)
         )
         dtype = self.resident.dtypes[level]
-        return self._create_volume(
+        resource = self._create_volume(
             np.zeros(shape, dtype=dtype),
             level,
             (0,) * len(shape),
             step_scale=step_scale,
         )
+        resource[2].update_drawings()
+        return resource
 
     def _create_volume(
         self,
@@ -356,6 +288,8 @@ class ChimeraXVolumeTarget:
             origin_xyz = tuple(reversed(origin))
 
         grid = ArrayGridData(buffer, origin=origin_xyz, step=step_xyz, name=f"{self.name} L{level}")
+        grid.channel = self.channel_index
+        grid.time = self.time_index
         volume = volume_from_grid_data(
             grid,
             self.session,
@@ -373,32 +307,85 @@ class ChimeraXVolumeTarget:
             "time" in [axis.type for axis in self.metadata.multiscales.axes],
             self.name,
         )
-        volume.set_parameters(colormap_on_gpu=True)
         volume.display = False
         self.owner.add([volume])
         return buffer, grid, volume
+
+    def _link_channel_volumes(self, level: int) -> None:
+        volumes = []
+        for controller in getattr(self.owner, "controllers", ()):
+            for window, (_buffer, _grid, volume) in controller.target.resources.items():
+                if window.level == level and not volume.deleted:
+                    volumes.append(volume)
+                    break
+        if len(volumes) > 1:
+            from chimerax.map.volume import MapChannels
+
+            MapChannels(sorted(volumes, key=lambda volume: volume.data.channel))
+
+    def _schedule_snapshot_publish(self, window: ResidentWindow, volume) -> None:
+        def publish() -> None:
+            resource = self.resources.get(window)
+            if volume.deleted or resource is None or resource[2] is not volume:
+                return
+            # Texture creation during a graphics-update trigger can disturb
+            # that frame on older ChimeraX Dailies. Run between frames instead.
+            volume.update_drawings()
+            self._published_windows.add(window)
+            presenter = getattr(self.owner, "present_lodstone_level", None)
+            if presenter is None:
+                self._show_window(window)
+            else:
+                presenter(window.level)
+            self.session.main_view.redraw_needed = True
+
+        ui = getattr(self.session, "ui", None)
+        if ui is None or not ui.is_gui:
+            publish()
+            return
+        timers = getattr(self.session, "_lodstone_publish_timers", [])
+        timers.append(ui.timer(0, publish))
+        self.session._lodstone_publish_timers = timers
 
     def _show_window(self, window: ResidentWindow) -> None:
         if self.current_window is window:
             return
         active = self._channel_active()
         if self._bounds_resource is not None:
-            self._bounds_resource[2].display = False
+            # The proxy has done its job once a completed resident volume can
+            # supply real bounds. Removing it also makes ChimeraX recompute
+            # clipping/drawings for the newly visible child on older Dailies.
+            self._delete_volume(self._bounds_resource[2])
+            self._bounds_resource = None
         for existing, (_buffer, _grid, volume) in self.resources.items():
             volume.display = active and existing is window
         self.current_window = window
 
     def _retire_window(self, window: ResidentWindow) -> None:
         resource = self.resources.pop(window, None)
+        self._published_windows.discard(window)
         self._value_ranges.pop(window, None)
         if resource is not None:
             self._delete_volume(resource[2])
         if self.current_window is window:
             self.current_window = None
 
+    def _flush_deferred_retired(self) -> None:
+        for window in tuple(self._deferred_retired):
+            if window is not self.current_window:
+                self._deferred_retired.discard(window)
+                self._retire_window(window)
+
     @staticmethod
     def _delete_volume(volume) -> None:
         volume.display = False
+        manager = getattr(volume.session, "_volume_update_manager", None)
+        if manager is not None:
+            # ChimeraX Daily builds before 2026-08-17 can retain a hidden or
+            # deleted volume in only one of these two companion sets, then
+            # raise KeyError on the next graphics update.
+            manager._volumes_to_update.discard(volume)
+            manager._displayed_volumes_to_update.discard(volume)
         volume.delete()
 
     def _channel_active(self) -> bool:
@@ -479,8 +466,15 @@ class LodstoneVolumeController:
         view, signature = self._view()
         if self._signature is not None and np.allclose(signature, self._signature, rtol=1e-7, atol=1e-7):
             return
+        plan = self.stream.plan(view)
+        if not plan.desired:
+            self.session.logger.status(
+                f"Lodstone {self.target.name}: waiting for a valid fitted view",
+                blank_after=3,
+            )
+            return
         self._signature = signature
-        plan = self.stream.update(view)
+        self.stream.submit(view, plan)
         message = f"Lodstone {self.target.name}: loading {len(plan.wanted)} blocks toward level {plan.target_level}"
         self.session.logger.status(message, blank_after=3)
 
@@ -524,7 +518,24 @@ class LodstoneVolumeController:
             world_to_clip=world_to_clip,
             eye=eye_local,
         )
-        signature = np.concatenate([world_to_clip.ravel(), np.asarray(window_size)]).astype(np.float64)
+        # ChimeraX recomputes near/far clipping distances as streamed child
+        # volumes are shown. Those values affect world_to_clip but are not a
+        # user view change; including them here caused an endless sequence of
+        # canceled generations. Track camera/model transforms and projection
+        # intrinsics instead.
+        intrinsics = [
+            float(getattr(camera, name))
+            for name in ("field_of_view", "field_width")
+            if hasattr(camera, name)
+        ]
+        signature = np.concatenate(
+            [
+                np.asarray(camera.position.matrix, dtype=np.float64).ravel(),
+                np.asarray(self.owner.scene_position.matrix, dtype=np.float64).ravel(),
+                np.asarray(window_size, dtype=np.float64),
+                np.asarray(intrinsics, dtype=np.float64),
+            ],
+        )
         return view, signature
 
     def close(self) -> None:
@@ -598,6 +609,19 @@ class LodstoneZarrModel(Model):
     @property
     def scales(self):
         return [dataset.path for dataset in self.ome_zarr_metadata.multiscales.datasets]
+
+    def present_lodstone_level(self, level: int) -> None:
+        windows = []
+        for controller in self.controllers:
+            window = controller.target.resident.windows.get(level)
+            if window is None or window not in controller.target._published_windows:
+                return
+            windows.append((controller.target, window))
+        for target, window in windows:
+            target._show_window(window)
+        for target, _window in windows:
+            target._flush_deferred_retired()
+        self.session.main_view.redraw_needed = True
 
     def delete(self) -> None:
         for controller in self.controllers:

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -29,16 +29,6 @@ from .map_data.zarr_grid import _apply_omero_display
 DEFAULT_GPU_BUDGET = 256 * 1024**2
 
 
-def _update_volume_now(volume) -> None:
-    """Update one volume without leaving it in ChimeraX's global update sets."""
-
-    volume.update_drawings()
-    manager = getattr(volume.session, "_volume_update_manager", None)
-    if manager is not None:
-        manager._volumes_to_update.discard(volume)
-        manager._displayed_volumes_to_update.discard(volume)
-
-
 def _upload_texture_3d(texture, data: np.ndarray, offset_zyx) -> None:
     """Upload one scalar ZYX subarray into an initialized ChimeraX texture."""
 
@@ -274,7 +264,6 @@ class ChimeraXVolumeTarget:
                 self.displayed_axes,
             ):
                 grid.values_changed()
-            _update_volume_now(volume)
             self._show_window(change.window)
 
     def phase_complete(self, view, plan, phase: int) -> None:
@@ -398,8 +387,6 @@ class ChimeraXVolumeTarget:
             self._bounds_resource[2].display = False
         for existing, (_buffer, _grid, volume) in self.resources.items():
             volume.display = active and existing is window
-            if volume.display:
-                _update_volume_now(volume)
         self.current_window = window
 
     def _retire_window(self, window: ResidentWindow) -> None:

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -22,6 +22,7 @@ from lodstone import (
     ResidentLease,
     ResidentTransition,
     ResidentWindow,
+    Runtime,
     Stream,
     TileKey,
     Update,
@@ -913,6 +914,7 @@ class LodstoneVolumeController:
             cpu_cache=max(2 * target.gpu_budget, 256 * 1024**2),
             inflight=min(target.gpu_budget, 128 * 1024**2),
             batch_size=8,
+            runtime=owner.runtime,
         )
         self._disconnect_status = self.stream.on_status_changed(self._status_changed)
         self._handler = self.session.triggers.add_handler("graphics update", self._graphics_update)
@@ -1096,6 +1098,7 @@ class LodstoneZarrModel(Model):
     ) -> None:
         super().__init__(name, session)
         self.dispatcher = None
+        self.runtime = None
         self.controllers = []
         self.group = group
         self.ome_zarr_metadata = metadata = parse_ome_zarr_metadata(group)
@@ -1115,6 +1118,7 @@ class LodstoneZarrModel(Model):
             )
 
         self.dispatcher = ChimeraXDispatcher(session)
+        self.runtime = Runtime(compute_workers=2)
         for time_index in range(time_count):
             for channel_index in range(channel_count):
                 index = [None] * len(multiscales.axes)
@@ -1200,6 +1204,9 @@ class LodstoneZarrModel(Model):
     def delete(self) -> None:
         for controller in self.controllers:
             controller.close()
+        if self.runtime is not None:
+            self.runtime.close()
+            self.runtime = None
         if self.dispatcher is not None:
             self.dispatcher.close()
         super().delete()

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -258,8 +258,7 @@ class ChimeraXVolumeTarget:
         full_shape = tuple(info.shape[axis] for axis in self.displayed_axes)
         shape = tuple(min(size, 2) for size in full_shape)
         step_scale = tuple(
-            (full_size - 1) / (size - 1) if size > 1 else 1.0
-            for full_size, size in zip(full_shape, shape, strict=True)
+            (full_size - 1) / (size - 1) if size > 1 else 1.0 for full_size, size in zip(full_shape, shape, strict=True)
         )
         dtype = self.resident.dtypes[level]
         resource = self._create_volume(
@@ -449,6 +448,7 @@ class LodstoneVolumeController:
         self.dispatcher = dispatcher
         self._signature = None
         self._target_level = None
+        self._active_coverage = None
         self._pending_view = None
         self._debounce_timer = None
         self.stream = Stream(
@@ -508,8 +508,11 @@ class LodstoneVolumeController:
                 blank_after=3,
             )
             return
+        if plan.coverage == self._active_coverage:
+            return
         self._target_level = plan.target_level
         self.stream.submit(view, plan)
+        self._active_coverage = plan.coverage
         message = f"Lodstone {self.target.name}: loading {len(plan.wanted)} blocks toward level {plan.target_level}"
         self.session.logger.status(message, blank_after=3)
 
@@ -559,9 +562,7 @@ class LodstoneVolumeController:
         # canceled generations. Track camera/model transforms and projection
         # intrinsics instead.
         intrinsics = [
-            float(getattr(camera, name))
-            for name in ("field_of_view", "field_width")
-            if hasattr(camera, name)
+            float(getattr(camera, name)) for name in ("field_of_view", "field_width") if hasattr(camera, name)
         ]
         signature = np.concatenate(
             [

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -1127,14 +1127,12 @@ class LodstoneZarrModel(Model):
         channel_count = finest_shape[channel_axis] if channel_axis is not None else 1
         if time_count > 1 and time_index is None:
             raise OMEZarrFormatError(
-                "Lodstone streaming requires one timepoint; add for example "
-                "'time 0' to the open command.",
+                "Lodstone streaming requires one timepoint; add for example 'time 0' to the open command.",
             )
         selected_time = 0 if time_index is None else time_index
         if not 0 <= selected_time < time_count:
             raise OMEZarrFormatError(
-                f"time {selected_time} is outside the available range "
-                f"0-{time_count - 1}.",
+                f"time {selected_time} is outside the available range 0-{time_count - 1}.",
             )
 
         self.dispatcher = ChimeraXDispatcher(session)

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -27,6 +27,8 @@ from .map_data.ome_metadata import OMEZarrFormatError, parse_ome_zarr_metadata, 
 from .map_data.zarr_grid import _apply_omero_display
 
 DEFAULT_GPU_BUDGET = 256 * 1024**2
+CAMERA_DEBOUNCE_MS = 180
+LOD_HYSTERESIS = 0.2
 
 
 def _homogeneous_place(place) -> np.ndarray:
@@ -152,7 +154,10 @@ class ChimeraXVolumeTarget:
     def prepare(self, view, plan) -> None:
         transition = self.resident.prepare(plan)
         for window in transition.retired:
-            self._retire_window(window)
+            if window is self.current_window:
+                self._deferred_retired.add(window)
+            else:
+                self._retire_window(window)
         for window in transition.prepared:
             self._ensure_window(window)
         if self.current_window is None:
@@ -443,10 +448,13 @@ class LodstoneVolumeController:
         self.displayed_axes = tuple(displayed_axes)
         self.dispatcher = dispatcher
         self._signature = None
+        self._target_level = None
+        self._pending_view = None
+        self._debounce_timer = None
         self.stream = Stream(
             source,
             target,
-            planner=Planner(progressive=True),
+            planner=Planner(progressive=True, max_intermediate_levels=0),
             dispatch=dispatcher,
             workers=8,
             cpu_cache=max(2 * target.gpu_budget, 256 * 1024**2),
@@ -466,14 +474,41 @@ class LodstoneVolumeController:
         view, signature = self._view()
         if self._signature is not None and np.allclose(signature, self._signature, rtol=1e-7, atol=1e-7):
             return
-        plan = self.stream.plan(view)
+        self._signature = signature
+        if self._target_level is None:
+            self._submit_view(view)
+            return
+
+        self._pending_view = view
+        timer = self._debounce_timer
+        if timer is not None:
+            timer.stop()
+        ui = getattr(self.session, "ui", None)
+        if ui is None or not ui.is_gui:
+            self._submit_pending_view()
+        else:
+            self._debounce_timer = ui.timer(CAMERA_DEBOUNCE_MS, self._submit_pending_view)
+
+    def _submit_pending_view(self) -> None:
+        view = self._pending_view
+        self._pending_view = None
+        self._debounce_timer = None
+        if view is not None and not self.owner.deleted:
+            self._submit_view(view)
+
+    def _submit_view(self, view: View) -> None:
+        plan = self.stream.plan(
+            view,
+            previous_target_level=self._target_level,
+            lod_hysteresis=LOD_HYSTERESIS,
+        )
         if not plan.desired:
             self.session.logger.status(
                 f"Lodstone {self.target.name}: waiting for a valid fitted view",
                 blank_after=3,
             )
             return
-        self._signature = signature
+        self._target_level = plan.target_level
         self.stream.submit(view, plan)
         message = f"Lodstone {self.target.name}: loading {len(plan.wanted)} blocks toward level {plan.target_level}"
         self.session.logger.status(message, blank_after=3)
@@ -539,6 +574,9 @@ class LodstoneVolumeController:
         return view, signature
 
     def close(self) -> None:
+        if self._debounce_timer is not None:
+            self._debounce_timer.stop()
+            self._debounce_timer = None
         if self._handler is not None:
             self._handler.remove()
             self._handler = None

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -254,6 +254,9 @@ class ChimeraXVolumeTarget:
                 if value is not None
             ),
             memory_policy="crop",
+            # Translucent volumes benefit from a camera-centered column of
+            # detail before spending the entire focus budget on a near slab.
+            focus_depth_weight=0.5,
         )
 
     def register_plan(self, plan, request_epoch: int, reason: str) -> None:

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -835,6 +835,12 @@ class ChimeraXVolumeTarget:
 
     @staticmethod
     def _delete_volume(volume) -> None:
+        # A front buffer can also remain referenced by a deferred resident
+        # window after the multichannel coordinator has retired it.  ChimeraX
+        # treats a repeated Model.delete() as an error, so deletion is the
+        # idempotent ownership boundary for all of those retirement paths.
+        if volume.deleted:
+            return
         volume.display = False
         manager = getattr(volume.session, "_volume_update_manager", None)
         if manager is not None:

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -1101,6 +1101,7 @@ class LodstoneZarrModel(Model):
         group,
         *,
         gpu_budget: int = DEFAULT_GPU_BUDGET,
+        time_index: int | None = None,
     ) -> None:
         super().__init__(name, session)
         self.dispatcher = None
@@ -1117,41 +1118,46 @@ class LodstoneZarrModel(Model):
         finest_shape = self.source.pyramid.levels[0].shape
         time_count = finest_shape[time_axis] if time_axis is not None else 1
         channel_count = finest_shape[channel_axis] if channel_axis is not None else 1
-        if time_count > 1:
+        if time_count > 1 and time_index is None:
             raise OMEZarrFormatError(
-                "Lodstone streaming does not yet support switching timepoints; "
-                "open this time series without 'streaming true'.",
+                "Lodstone streaming requires one timepoint; add for example "
+                "'time 0' to the open command.",
+            )
+        selected_time = 0 if time_index is None else time_index
+        if not 0 <= selected_time < time_count:
+            raise OMEZarrFormatError(
+                f"time {selected_time} is outside the available range "
+                f"0-{time_count - 1}.",
             )
 
         self.dispatcher = ChimeraXDispatcher(session)
         self.runtime = Runtime(compute_workers=2)
-        for time_index in range(time_count):
-            for channel_index in range(channel_count):
-                index = [None] * len(multiscales.axes)
-                if time_axis is not None:
-                    index[time_axis] = time_index
-                if channel_axis is not None:
-                    index[channel_axis] = channel_index
-                target = ChimeraXVolumeTarget(
+        for channel_index in range(channel_count):
+            index = [None] * len(multiscales.axes)
+            if time_axis is not None:
+                index[time_axis] = selected_time
+            if channel_axis is not None:
+                index[channel_axis] = channel_index
+            target = ChimeraXVolumeTarget(
+                self,
+                self.source,
+                metadata,
+                displayed_axes,
+                name=name,
+                channel_index=channel_index,
+                time_index=selected_time,
+                gpu_budget=gpu_budget,
+            )
+            self.controllers.append(
+                LodstoneVolumeController(
                     self,
                     self.source,
-                    metadata,
+                    target,
+                    index,
                     displayed_axes,
-                    name=name,
-                    channel_index=channel_index,
-                    time_index=time_index,
-                    gpu_budget=gpu_budget,
-                )
-                self.controllers.append(
-                    LodstoneVolumeController(
-                        self,
-                        self.source,
-                        target,
-                        index,
-                        displayed_axes,
-                        self.dispatcher,
-                    ),
-                )
+                    self.dispatcher,
+                ),
+            )
 
     @property
     def scales(self):

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -6,6 +6,7 @@ from collections import deque
 from collections.abc import Collection, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from itertools import product
 from threading import Lock
 from time import perf_counter
 
@@ -27,6 +28,7 @@ from lodstone import (
     TileKey,
     Update,
     View,
+    merge_plans,
 )
 from lodstone.sources import ArrayPyramidSource
 
@@ -78,6 +80,17 @@ class PreparedResidency:
     desired_keys: frozenset[TileKey]
     request_epoch: int
     reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class VolumeDisplayState:
+    """User-controlled image display parameters shared by clipmap levels."""
+
+    image_levels: tuple[tuple[float, float], ...]
+    image_colors: tuple[tuple[float, ...], ...]
+    image_brightness_factor: float
+    transparency_depth: float
+    default_rgba: tuple[float, ...]
 
 
 def _homogeneous_place(place) -> np.ndarray:
@@ -177,6 +190,11 @@ class ChimeraXVolumeTarget:
         self.gpu_budget = gpu_budget
         self.snapshot_budget = min(int(snapshot_budget), gpu_budget)
         self.upload_budget = min(int(upload_budget), gpu_budget)
+        self.context_budget = min(
+            self.gpu_budget,
+            self.snapshot_budget,
+            self.upload_budget,
+        )
         self.max_focus_dimension = int(max_focus_dimension)
         self.max_texture_extent = self._maximum_texture_extent()
         dtypes = [
@@ -197,16 +215,21 @@ class ChimeraXVolumeTarget:
         self.resources = {}
         self.current_window = None
         self._front_resource = None
+        self._front_resources = {}
         self._back_resources = {}
         self._pending_publication = None
         self._publication_context = {}
         self._published_windows = set()
         self._deferred_retired = set()
+        self._context_level = len(source.pyramid.levels) - 1
+        self._planned_target_level = None
+        self._masked_focus = None
+        self._display_state = None
+        self._synchronizing_display = False
 
         # Establish bounds before the first camera-driven plan. This lets the
         # normal ChimeraX open/view logic position the camera around the data.
-        coarsest = len(source.pyramid.levels) - 1
-        self._bounds_resource = self._create_bounds_volume(coarsest)
+        self._bounds_resource = self._create_bounds_volume(self._context_level)
         self._bounds_resource[2].display = self._channel_active()
 
     def layout(self, view, pyramid) -> Layout:
@@ -215,7 +238,7 @@ class ChimeraXVolumeTarget:
             # Logical focus blocks remain small while Stream's native-chunk
             # cache coalesces the larger underlying Zarr chunk reads.
             block_shape=(64, 128, 128),
-            mixed_lod=False,
+            mixed_lod=True,
             memory_limit=min(
                 self.gpu_budget,
                 self.snapshot_budget,
@@ -236,6 +259,7 @@ class ChimeraXVolumeTarget:
     def register_plan(self, plan, request_epoch: int, reason: str) -> None:
         with self._state_lock:
             self._current_request_epoch = request_epoch
+            self._planned_target_level = plan.target_level
             self._plan_context[id(plan)] = (request_epoch, reason)
             if len(self._plan_context) > 16:
                 oldest = next(iter(self._plan_context))
@@ -548,7 +572,7 @@ class ChimeraXVolumeTarget:
 
     def complete(self, view, plan) -> None:
         started = perf_counter()
-        transition = self.resident.complete(plan)
+        transition = self.resident.complete(plan, retain_levels=True)
         for window in transition.retired:
             if window is self.current_window:
                 self._deferred_retired.add(window)
@@ -556,6 +580,7 @@ class ChimeraXVolumeTarget:
                 self._retire_window(window)
         with self.resident.lock:
             target = self.resident.active.get(plan.target_level)
+        presenter = None
         if target is not None:
             presenter = getattr(self.owner, "present_lodstone_level", None)
             if presenter is None:
@@ -563,6 +588,10 @@ class ChimeraXVolumeTarget:
                 self._flush_deferred_retired()
             else:
                 presenter(target.level)
+        if presenter is None:
+            self._retain_clipmap_levels({self._context_level, plan.target_level})
+        if plan.target_level == self._context_level:
+            self._restore_context()
         if self._bounds_resource is not None:
             self._delete_volume(self._bounds_resource[2])
             self._bounds_resource = None
@@ -654,6 +683,11 @@ class ChimeraXVolumeTarget:
         )
         volume.display = False
         self.owner.add([volume])
+        add_callback = getattr(volume, "add_volume_change_callback", None)
+        if add_callback is not None:
+            add_callback(self._volume_changed)
+        if self._display_state is not None:
+            self._apply_display_state(volume, self._display_state)
         self._record_timing(
             "_create_volume",
             started,
@@ -789,10 +823,12 @@ class ChimeraXVolumeTarget:
             # clipping/drawings for the newly visible child on older Dailies.
             self._delete_volume(self._bounds_resource[2])
             self._bounds_resource = None
+        keep = {self._context_level, window.level}
         for existing, (_buffer, _grid, volume) in self.resources.items():
-            volume.display = active and existing is window
+            volume.display = active and existing.level in keep
         self.current_window = window
         self._front_resource = (window, resource)
+        self._front_resources[window.level] = (window, resource)
 
     def _activate_back(self, level: int):
         """Atomically select an initialized back buffer, returning the old front."""
@@ -801,7 +837,8 @@ class ChimeraXVolumeTarget:
         if candidate is None:
             return None
         window, resource = candidate
-        old = None if self._front_resource is None else self._front_resource[1]
+        previous = self._front_resources.get(level)
+        old = None if previous is None else previous[1]
         active = self._channel_active()
         resource[2].display = active
         if old is not None and old is not resource:
@@ -811,10 +848,91 @@ class ChimeraXVolumeTarget:
             self._bounds_resource = None
         self.current_window = window
         self._front_resource = candidate
+        self._front_resources[level] = candidate
+        if level == self._context_level:
+            self._masked_focus = None
+            focus = self._active_focus_publication()
+            if focus is not None:
+                self._mask_context(focus)
+        else:
+            publication = self._publication_context.get(resource[2])
+            if publication is not None:
+                self._mask_context(publication)
         return old if old is not resource else None
 
     def _is_front_volume(self, volume) -> bool:
-        return self._front_resource is not None and self._front_resource[1][2] is volume
+        return any(resource[1][2] is volume for resource in self._front_resources.values())
+
+    def _retain_clipmap_levels(self, keep: set[int]) -> None:
+        """Retire renderer resources outside the context/focus clipmap pair."""
+        for window in tuple(self.resources):
+            if window.level not in keep and window is not self.current_window:
+                self._retire_window(window)
+
+    def _hide_other_focus_levels(self, level: int) -> None:
+        keep = {self._context_level, level}
+        for existing_level, (_window, resource) in self._front_resources.items():
+            if existing_level not in keep:
+                resource[2].display = False
+
+    def _active_focus_publication(self) -> PreparedPublication | None:
+        candidates = [
+            (level, candidate) for level, candidate in self._front_resources.items() if level != self._context_level
+        ]
+        if not candidates:
+            return None
+        _level, (_window, resource) = min(candidates, key=lambda item: item[0])
+        return self._publication_context.get(resource[2])
+
+    def _restore_context(self) -> None:
+        candidate = self._front_resources.get(self._context_level)
+        if candidate is None or self._masked_focus is None:
+            return
+        _window, (base, grid, _volume) = candidate
+        grid.array = base
+        values_changed = getattr(grid, "values_changed", None)
+        if values_changed is not None:
+            values_changed()
+        self._masked_focus = None
+
+    def _mask_context(self, focus: PreparedPublication) -> None:
+        """Keep coarse context outside occupied fine focus samples."""
+        candidate = self._front_resources.get(self._context_level)
+        identity = (focus.level, focus.region)
+        if candidate is None or self._masked_focus == identity:
+            return
+        _window, (base, grid, volume) = candidate
+        context = self._publication_context.get(volume)
+        if context is None:
+            return
+        overlap = _region_in_level(
+            focus.region,
+            focus.transform,
+            context.transform,
+        ).intersection(context.region)
+        masked = base.copy()
+        if overlap is not None:
+            if np.count_nonzero(focus.array) == focus.array.size:
+                slices = tuple(
+                    slice(
+                        overlap.start[axis] - context.region.start[axis],
+                        overlap.stop[axis] - context.region.start[axis],
+                    )
+                    for axis in self.displayed_axes
+                )
+                masked[slices] = 0
+            else:
+                _mask_occupied_context(
+                    masked,
+                    context,
+                    focus,
+                    self.displayed_axes,
+                )
+        grid.array = masked
+        values_changed = getattr(grid, "values_changed", None)
+        if values_changed is not None:
+            values_changed()
+        self._masked_focus = identity
 
     def _retire_window(self, window: ResidentWindow) -> None:
         resource = self.resources.pop(window, None)
@@ -822,7 +940,11 @@ class ChimeraXVolumeTarget:
             if candidate[0] is window:
                 self._back_resources.pop(level, None)
         self._published_windows.discard(window)
-        if resource is not None and not self._is_front_volume(resource[2]):
+        front = self._front_resources.get(window.level)
+        if front is not None and front[0] is window:
+            self._front_resources.pop(window.level, None)
+        if resource is not None:
+            self._publication_context.pop(resource[2], None)
             self._delete_volume(resource[2])
         if self.current_window is window:
             self.current_window = None
@@ -864,6 +986,9 @@ class ChimeraXVolumeTarget:
         value_range: tuple[float, float] | None,
     ) -> None:
         volume = self.resources[window][2]
+        if self._display_state is not None:
+            self._apply_display_state(volume, self._display_state)
+            return
         omero = self.metadata.omero
         if omero and self.channel_index < len(omero.channels):
             display_window = omero.channels[self.channel_index].window
@@ -874,9 +999,114 @@ class ChimeraXVolumeTarget:
                         (display_window.end, 1.0),
                     ],
                 )
-                return
-        if value_range is not None and value_range[1] > value_range[0]:
+        elif value_range is not None and value_range[1] > value_range[0]:
             volume.set_parameters(image_levels=[(value_range[0], 0.0), (value_range[1], 1.0)])
+        state = self._capture_display_state(volume)
+        if state is not None:
+            self._display_state = state
+
+    def _volume_changed(self, volume, change: str) -> None:
+        if self._synchronizing_display or change not in {
+            "thresholds changed",
+            "colors changed",
+        }:
+            return
+        state = self._capture_display_state(volume)
+        if state is None:
+            return
+        self._display_state = state
+        self._synchronizing_display = True
+        try:
+            for _buffer, _grid, other in self.resources.values():
+                if other is not volume and not other.deleted:
+                    self._apply_display_state(other, state)
+        finally:
+            self._synchronizing_display = False
+
+    @staticmethod
+    def _capture_display_state(volume) -> VolumeDisplayState | None:
+        attributes = (
+            "image_levels",
+            "image_colors",
+            "image_brightness_factor",
+            "transparency_depth",
+            "default_rgba",
+        )
+        if any(not hasattr(volume, attribute) for attribute in attributes):
+            return None
+        return VolumeDisplayState(
+            tuple(tuple(value) for value in volume.image_levels),
+            tuple(tuple(value) for value in volume.image_colors),
+            float(volume.image_brightness_factor),
+            float(volume.transparency_depth),
+            tuple(float(value) for value in volume.default_rgba),
+        )
+
+    def _apply_display_state(self, volume, state: VolumeDisplayState) -> None:
+        guarded = self._synchronizing_display
+        self._synchronizing_display = True
+        try:
+            volume.set_parameters(
+                image_levels=state.image_levels,
+                image_colors=state.image_colors,
+                image_brightness_factor=state.image_brightness_factor,
+                transparency_depth=state.transparency_depth,
+                default_rgba=state.default_rgba,
+            )
+        finally:
+            self._synchronizing_display = guarded
+
+
+def _region_in_level(
+    region: Region,
+    source_to_world: np.ndarray,
+    destination_to_world: np.ndarray,
+) -> Region:
+    """Return a conservative destination-level box for ``region``."""
+    ndim = region.ndim
+    destination_from_source = np.linalg.solve(destination_to_world, source_to_world)
+    corners = np.asarray(
+        [(*corner, 1.0) for corner in product(*zip(region.start, region.stop, strict=True))],
+        dtype=np.float64,
+    )
+    mapped = (destination_from_source @ corners.T).T[:, :ndim]
+    start = tuple(max(0, int(np.floor(value))) for value in mapped.min(axis=0))
+    stop = tuple(max(0, int(np.ceil(value))) for value in mapped.max(axis=0))
+    return Region(start, stop)
+
+
+def _mask_occupied_context(
+    masked: np.ndarray,
+    context: PreparedPublication,
+    focus: PreparedPublication,
+    displayed_axes: tuple[int, ...],
+) -> None:
+    """Mask coarse samples covered by nonzero fine focus samples."""
+    context_from_focus = np.linalg.solve(context.transform, focus.transform)
+    ndim = focus.region.ndim
+    base = np.asarray(focus.region.start, dtype=np.float64) + 0.5
+    data = focus.array
+    for leading in range(data.shape[0]):
+        occupied = np.argwhere(data[leading] != 0)
+        if not len(occupied):
+            continue
+        local = np.column_stack(
+            (np.full(len(occupied), leading, dtype=np.int64), occupied),
+        )
+        points = np.broadcast_to(base, (len(local), ndim)).copy()
+        for local_axis, data_axis in enumerate(displayed_axes):
+            points[:, data_axis] += local[:, local_axis]
+        homogeneous = np.column_stack((points, np.ones(len(points))))
+        mapped = (context_from_focus @ homogeneous.T).T[:, :ndim]
+        indices = np.floor(mapped).astype(np.int64)
+        context_indices = np.column_stack(
+            [indices[:, axis] - context.region.start[axis] for axis in displayed_axes],
+        )
+        valid = np.ones(len(context_indices), dtype=bool)
+        for axis, size in enumerate(masked.shape):
+            valid &= (context_indices[:, axis] >= 0) & (context_indices[:, axis] < size)
+        if np.any(valid):
+            masked[tuple(context_indices[valid].T)] = 0
 
 
 class LodstoneVolumeController:
@@ -967,11 +1197,7 @@ class LodstoneVolumeController:
 
         def calculate():
             started = perf_counter()
-            plan = self.stream.plan(
-                view,
-                previous_target_level=previous_target_level,
-                lod_hysteresis=LOD_HYSTERESIS,
-            )
+            plan = self._plan_view(view, previous_target_level)
             self.target._record_timing(
                 "stream.plan",
                 started,
@@ -1003,6 +1229,26 @@ class LodstoneVolumeController:
             self.dispatcher(submit)
 
         future.add_done_callback(planned)
+
+    def _plan_view(self, view: View, previous_target_level: int | None):
+        plan = self.stream.plan(
+            view,
+            previous_target_level=previous_target_level,
+            lod_hysteresis=LOD_HYSTERESIS,
+        )
+        context = self.source.pyramid.levels[-1]
+        context_shape = tuple(context.shape[axis] for axis in self.displayed_axes)
+        max_extent = self.target.layout(view, self.source.pyramid).max_axis_extent
+        if all(size <= max_extent for size in context_shape):
+            overview = self.stream.planner.plan_overview(
+                self.source.pyramid,
+                view,
+                memory_limit=self.target.context_budget,
+                available=self.stream.available,
+            )
+            if overview.desired:
+                plan = merge_plans(plan, overview)
+        return plan
 
     def _submit_planned(self, view, plan, request_epoch: int, reason: str) -> None:
         if request_epoch != self._request_epoch or self.owner.deleted:
@@ -1200,6 +1446,14 @@ class LodstoneZarrModel(Model):
             old = target._activate_back(level) if activate is None else activate(level)
             if old is not None:
                 retired.append((target, old))
+        final_selection = all(
+            getattr(target, "_planned_target_level", level) == level for target, _window in candidates
+        )
+        if final_selection:
+            for target, _window in candidates:
+                hide = getattr(target, "_hide_other_focus_levels", None)
+                if hide is not None:
+                    hide(level)
 
         # Every new channel is selected before any old front is destroyed.
         # ChimeraX has no public texture-upload completion fence. Retain the
@@ -1213,7 +1467,11 @@ class LodstoneZarrModel(Model):
                 else:
                     target._timed_delete(resource[2], publication)
             for target, _window in candidates:
-                target._flush_deferred_retired()
+                if final_selection:
+                    retain = getattr(target, "_retain_clipmap_levels", None)
+                    if retain is not None:
+                        retain({target._context_level, level})
+                    target._flush_deferred_retired()
 
         self.dispatcher(retire_previous_fronts)
         self.session.main_view.redraw_needed = True

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections import defaultdict, deque
+from collections import deque
 from collections.abc import Collection, Sequence
 from threading import Lock
 
@@ -10,12 +10,21 @@ import numpy as np
 from chimerax.core.models import Model
 from chimerax.map import volume_from_grid_data
 from chimerax.map_data import ArrayGridData
-from lodstone import Layout, Planner, Stream, TileKey, Update, View
+from lodstone import (
+    Layout,
+    Planner,
+    ResidentArrays,
+    ResidentWindow,
+    Stream,
+    TileKey,
+    Update,
+    View,
+)
 from lodstone.sources import ArrayPyramidSource
 
 from .map_data.constants import UNITFACTOR
 from .map_data.ome_metadata import OMEZarrFormatError, parse_ome_zarr_metadata, spatial_transform_angstrom
-from .map_data.zarr_grid import _apply_omero_display, _supported_matrix_type
+from .map_data.zarr_grid import _apply_omero_display
 
 DEFAULT_GPU_BUDGET = 512 * 1024**2
 
@@ -97,7 +106,7 @@ class ChimeraXDispatcher:
 
 
 class ChimeraXVolumeTarget:
-    """Assemble Lodstone updates into mutable ChimeraX array-backed volumes."""
+    """Render bounded Lodstone resident windows as ChimeraX volumes."""
 
     def __init__(
         self,
@@ -120,18 +129,20 @@ class ChimeraXVolumeTarget:
         self.channel_index = channel_index
         self.time_index = time_index
         self.gpu_budget = gpu_budget
-        self.buffers = {}
-        self.grids = {}
-        self.volumes = {}
-        self.level_keys = defaultdict(set)
-        self.current_level = None
+        dtypes = [
+            np.float32 if level.dtype in (np.dtype(np.float16), np.dtype(np.uint64)) else level.dtype
+            for level in source.pyramid.levels
+        ]
+        self.resident = ResidentArrays(source.pyramid, dtypes=dtypes)
+        self.resources = {}
+        self.current_window = None
         self._value_ranges = {}
 
         # Establish bounds before the first camera-driven plan. This lets the
         # normal ChimeraX open/view logic position the camera around the data.
         coarsest = len(source.pyramid.levels) - 1
-        self._ensure_level(coarsest)
-        self._show_level(coarsest)
+        self._bounds_resource = self._create_bounds_volume(coarsest)
+        self._bounds_resource[2].display = self._channel_active()
 
     def layout(self, view, pyramid) -> Layout:
         return Layout(
@@ -141,56 +152,89 @@ class ChimeraXVolumeTarget:
             block_shape=None,
             mixed_lod=False,
             memory_limit=self.gpu_budget,
+            squeeze_hidden=False,
         )
 
-    def apply(self, updates: Sequence[Update]) -> None:
-        changed_levels = set()
-        for update in updates:
-            buffer, _grid, _volume = self._ensure_level(update.level)
-            slices = tuple(
-                slice(update.region.start[axis], update.region.stop[axis])
-                for axis in self.displayed_axes
-            )
-            values = _supported_matrix_type(update.data)
-            if len(self.displayed_axes) == 2:
-                slices = (slice(0, 1), *slices)
-                values = np.expand_dims(values, axis=0)
-            buffer[slices] = values
-            self.level_keys[update.level].add(update.key)
-            changed_levels.add(update.level)
-            self._observe_values(update.level, values)
+    def prepare(self, view, plan) -> None:
+        transition = self.resident.prepare(plan)
+        for window in transition.retired:
+            self._retire_window(window)
+        for window in transition.prepared:
+            self._ensure_window(window)
+        if self.current_window is None:
+            fallback = self.resident.active.get(plan.target_level)
+            if fallback is not None:
+                self._show_window(fallback)
+            elif self._bounds_resource is not None:
+                self._bounds_resource[2].display = self._channel_active()
 
-        for level in changed_levels:
-            self.grids[level].values_changed()
-            self._update_thresholds(level)
-            _update_volume_now(self.volumes[level])
-        if updates:
-            self._show_level(updates[-1].level)
+    def apply(self, updates: Sequence[Update]) -> None:
+        changes = self.resident.apply(updates)
+        for change in changes:
+            _buffer, grid, volume = self._ensure_window(change.window)
+            for update in change.updates:
+                self._observe_values(change.window, update.data)
+            grid.values_changed()
+            self._update_thresholds(change.window)
+            _update_volume_now(volume)
+            self._show_window(change.window)
 
     def discard(self, keys: Collection[TileKey]) -> None:
-        discarded_by_level = defaultdict(set)
-        for key in keys:
-            discarded_by_level[key.level].add(key)
-        for level, discarded in discarded_by_level.items():
-            self.level_keys[level].difference_update(discarded)
-            if not self.level_keys[level] and level in self.volumes:
-                self.volumes[level].display = False
+        self.resident.discard(keys)
+
+    def complete(self, view, plan) -> None:
+        transition = self.resident.complete(plan)
+        target = self.resident.active.get(plan.target_level)
+        if target is not None:
+            self._show_window(target)
+        for window in transition.retired:
+            self._retire_window(window)
+        if self._bounds_resource is not None:
+            self._delete_volume(self._bounds_resource[2])
+            self._bounds_resource = None
 
     def redraw(self) -> None:
         self.session.main_view.redraw_needed = True
 
-    def _ensure_level(self, level: int):
-        if level in self.buffers:
-            return self.buffers[level], self.grids[level], self.volumes[level]
+    def _ensure_window(self, window: ResidentWindow):
+        if window in self.resources:
+            return self.resources[window]
+        selection = tuple(slice(None) if axis in self.displayed_axes else 0 for axis in range(window.region.ndim))
+        buffer = window.data[selection]
+        spatial_start = tuple(window.region.start[axis] for axis in self.displayed_axes)
+        resource = self._create_volume(buffer, window.level, spatial_start)
+        self.resources[window] = resource
+        return resource
 
-        level_info = self.source.pyramid.levels[level]
-        spatial_shape = tuple(level_info.shape[axis] for axis in self.displayed_axes)
-        dtype = np.float32 if level_info.dtype in (np.dtype(np.float16), np.dtype(np.uint64)) else level_info.dtype
-        buffer = np.zeros(spatial_shape, dtype=dtype)
+    def _create_bounds_volume(self, level: int):
+        info = self.source.pyramid.levels[level]
+        full_shape = tuple(info.shape[axis] for axis in self.displayed_axes)
+        shape = tuple(min(size, 2) for size in full_shape)
+        step_scale = tuple(
+            (full_size - 1) / (size - 1) if size > 1 else 1.0 for full_size, size in zip(full_shape, shape, strict=True)
+        )
+        dtype = self.resident.dtypes[level]
+        return self._create_volume(
+            np.zeros(shape, dtype=dtype),
+            level,
+            (0,) * len(shape),
+            step_scale=step_scale,
+        )
 
+    def _create_volume(
+        self,
+        buffer,
+        level: int,
+        spatial_start,
+        *,
+        step_scale=None,
+    ):
         dataset = self.metadata.multiscales.datasets[level]
         step, origin = spatial_transform_angstrom(self.metadata.multiscales, dataset)
-        if len(spatial_shape) == 2:
+        if step_scale is not None:
+            step = tuple(value * factor for value, factor in zip(step, step_scale, strict=True))
+        origin = tuple(value + spatial_start[axis] * step[axis] for axis, value in enumerate(origin))
+        if len(self.displayed_axes) == 2:
             buffer = np.expand_dims(buffer, axis=0)
             step_xyz = (step[1], step[0], 1.0)
             origin_xyz = (origin[1], origin[0], 0.0)
@@ -218,21 +262,32 @@ class ChimeraXVolumeTarget:
         )
         volume.display = False
         self.owner.add([volume])
-
-        self.buffers[level] = buffer
-        self.grids[level] = grid
-        self.volumes[level] = volume
         return buffer, grid, volume
 
-    def _show_level(self, level: int) -> None:
-        if self.current_level == level:
+    def _show_window(self, window: ResidentWindow) -> None:
+        if self.current_window is window:
             return
         active = self._channel_active()
-        for existing_level, volume in self.volumes.items():
-            volume.display = active and existing_level == level
+        if self._bounds_resource is not None:
+            self._bounds_resource[2].display = False
+        for existing, (_buffer, _grid, volume) in self.resources.items():
+            volume.display = active and existing is window
             if volume.display:
                 _update_volume_now(volume)
-        self.current_level = level
+        self.current_window = window
+
+    def _retire_window(self, window: ResidentWindow) -> None:
+        resource = self.resources.pop(window, None)
+        self._value_ranges.pop(window, None)
+        if resource is not None:
+            self._delete_volume(resource[2])
+        if self.current_window is window:
+            self.current_window = None
+
+    @staticmethod
+    def _delete_volume(volume) -> None:
+        volume.display = False
+        volume.delete()
 
     def _channel_active(self) -> bool:
         omero = self.metadata.omero
@@ -240,26 +295,31 @@ class ChimeraXVolumeTarget:
             return omero.channels[self.channel_index].active
         return self.time_index == 0
 
-    def _observe_values(self, level: int, values: np.ndarray) -> None:
+    def _observe_values(self, window: ResidentWindow, values: np.ndarray) -> None:
         if values.size == 0:
             return
         minimum = float(np.min(values))
         maximum = float(np.max(values))
-        previous = self._value_ranges.get(level)
-        self._value_ranges[level] = (
+        previous = self._value_ranges.get(window)
+        self._value_ranges[window] = (
             minimum if previous is None else min(previous[0], minimum),
             maximum if previous is None else max(previous[1], maximum),
         )
 
-    def _update_thresholds(self, level: int) -> None:
-        volume = self.volumes[level]
+    def _update_thresholds(self, window: ResidentWindow) -> None:
+        volume = self.resources[window][2]
         omero = self.metadata.omero
         if omero and self.channel_index < len(omero.channels):
-            window = omero.channels[self.channel_index].window
-            if window is not None and window.end > window.start:
-                volume.set_parameters(image_levels=[(window.start, 0.0), (window.end, 1.0)])
+            display_window = omero.channels[self.channel_index].window
+            if display_window is not None and display_window.end > display_window.start:
+                volume.set_parameters(
+                    image_levels=[
+                        (display_window.start, 0.0),
+                        (display_window.end, 1.0),
+                    ],
+                )
                 return
-        value_range = self._value_ranges.get(level)
+        value_range = self._value_ranges.get(window)
         if value_range is not None and value_range[1] > value_range[0]:
             volume.set_parameters(image_levels=[(value_range[0], 0.0), (value_range[1], 1.0)])
 
@@ -303,10 +363,7 @@ class LodstoneVolumeController:
             return
         self._signature = signature
         plan = self.stream.update(view)
-        message = (
-            f"Lodstone {self.target.name}: loading {len(plan.wanted)} blocks "
-            f"toward level {plan.target_level}"
-        )
+        message = f"Lodstone {self.target.name}: loading {len(plan.wanted)} blocks toward level {plan.target_level}"
         self.session.logger.info(message)
 
     def _status_changed(self, status) -> None:
@@ -316,10 +373,7 @@ class LodstoneVolumeController:
             )
         elif status.state == "complete":
             mib = status.bytes_read / 1024**2
-            message = (
-                f"Lodstone {self.target.name}: level ready "
-                f"({status.resident} blocks, {mib:.1f} MiB read)"
-            )
+            message = f"Lodstone {self.target.name}: level ready ({status.resident} blocks, {mib:.1f} MiB read)"
             self.session.logger.info(message)
 
     def _view(self):

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -39,6 +39,84 @@ def _update_volume_now(volume) -> None:
         manager._displayed_volumes_to_update.discard(volume)
 
 
+def _upload_texture_3d(texture, data: np.ndarray, offset_zyx) -> None:
+    """Upload one scalar ZYX subarray into an initialized ChimeraX texture."""
+
+    from chimerax.graphics import opengl
+
+    data = np.ascontiguousarray(data)
+    texture_format, _internal_format, texture_dtype, _components = texture.texture_format(data)
+    z_offset, y_offset, x_offset = offset_zyx
+    depth, height, width = data.shape
+    gl = opengl.GL
+    target = texture.gl_target
+    gl.glBindTexture(target, texture.id)
+    try:
+        gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
+        gl.glTexSubImage3D(
+            target,
+            0,
+            x_offset,
+            y_offset,
+            z_offset,
+            width,
+            height,
+            depth,
+            texture_format,
+            texture_dtype,
+            data,
+        )
+    finally:
+        gl.glBindTexture(target, 0)
+
+
+def _patch_volume_texture(volume, buffer, window, updates, displayed_axes) -> bool:
+    """Patch an existing scalar 3D texture, returning false when unsafe."""
+
+    if buffer.ndim != 3:
+        return False
+    image = getattr(volume, "_image", None)
+    if image is None or getattr(image, "deleted", False):
+        return False
+    options = getattr(image, "_rendering_options", None)
+    if options is None or not options.colormap_on_gpu or getattr(image, "_blend_image", None) is not None:
+        return False
+
+    if getattr(image, "_p_mode", None) == "rays":
+        drawing = getattr(image, "_volume_raycast_drawing", None)
+    elif getattr(image, "_use_3d_texture", False):
+        drawing = getattr(image, "_planes_3d", None)
+    else:
+        return False
+    texture = getattr(drawing, "texture", None)
+    if (
+        texture is None
+        or texture.id is None
+        or texture.dimension != 3
+        or texture.data is not None
+        or texture._array_shape != tuple(buffer.shape)
+        or texture._numpy_dtype != buffer.dtype
+    ):
+        return False
+
+    patches = []
+    for update in updates:
+        starts = tuple(update.region.start[axis] - window.region.start[axis] for axis in displayed_axes)
+        stops = tuple(update.region.stop[axis] - window.region.start[axis] for axis in displayed_axes)
+        if any(
+            start < 0 or stop > size or stop <= start
+            for start, stop, size in zip(starts, stops, buffer.shape, strict=True)
+        ):
+            return False
+        patch = buffer[tuple(slice(start, stop) for start, stop in zip(starts, stops, strict=True))]
+        patches.append((patch, starts))
+
+    volume.session.main_view.render.make_current()
+    for patch, offset in patches:
+        _upload_texture_3d(texture, patch, offset)
+    return True
+
+
 def _homogeneous_place(place) -> np.ndarray:
     matrix = np.eye(4, dtype=np.float64)
     matrix[:3, :] = place.matrix
@@ -171,11 +249,18 @@ class ChimeraXVolumeTarget:
     def apply(self, updates: Sequence[Update]) -> None:
         changes = self.resident.apply(updates)
         for change in changes:
-            _buffer, grid, volume = self._ensure_window(change.window)
+            buffer, grid, volume = self._ensure_window(change.window)
             for update in change.updates:
                 self._observe_values(change.window, update.data)
-            grid.values_changed()
             self._update_thresholds(change.window)
+            if not _patch_volume_texture(
+                volume,
+                buffer,
+                change.window,
+                change.updates,
+                self.displayed_axes,
+            ):
+                grid.values_changed()
             _update_volume_now(volume)
             self._show_window(change.window)
 
@@ -260,6 +345,7 @@ class ChimeraXVolumeTarget:
             "time" in [axis.type for axis in self.metadata.multiscales.axes],
             self.name,
         )
+        volume.set_parameters(colormap_on_gpu=True)
         volume.display = False
         self.owner.add([volume])
         return buffer, grid, volume

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -239,6 +239,11 @@ class ChimeraXVolumeTarget:
                 oldest = next(iter(self._plan_context))
                 self._plan_context.pop(oldest, None)
 
+    def invalidate_request(self, request_epoch: int) -> None:
+        """Suppress stale texture publication as soon as motion resumes."""
+        with self._state_lock:
+            self._current_request_epoch = max(self._current_request_epoch, request_epoch)
+
     def stage_prepare(self, view, plan) -> PreparedResidency:
         request_epoch, reason = self._context(plan)
         started = perf_counter()
@@ -923,6 +928,8 @@ class LodstoneVolumeController:
         if self._signature is not None and np.allclose(signature, self._signature, rtol=1e-7, atol=1e-7):
             return
         self._signature = signature
+        self._request_epoch += 1
+        self.target.invalidate_request(self._request_epoch)
         if self._target_level is None:
             self._submit_view(view, reason="initial")
             return

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -29,6 +29,7 @@ from .map_data.zarr_grid import _apply_omero_display
 DEFAULT_GPU_BUDGET = 256 * 1024**2
 CAMERA_DEBOUNCE_MS = 180
 LOD_HYSTERESIS = 0.2
+MAX_INITIAL_VOXEL_FOOTPRINT = 4.0
 
 
 def _homogeneous_place(place) -> np.ndarray:
@@ -454,7 +455,11 @@ class LodstoneVolumeController:
         self.stream = Stream(
             source,
             target,
-            planner=Planner(progressive=True, max_intermediate_levels=0),
+            planner=Planner(
+                progressive=True,
+                max_intermediate_levels=0,
+                max_initial_voxel_footprint=MAX_INITIAL_VOXEL_FOOTPRINT,
+            ),
             dispatch=dispatcher,
             workers=8,
             cpu_cache=max(2 * target.gpu_budget, 256 * 1024**2),

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Collection, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from threading import Lock
+from time import perf_counter
 
 import numpy as np
 from chimerax.core.models import Model
@@ -12,9 +15,12 @@ from chimerax.map import volume_from_grid_data
 from chimerax.map_data import ArrayGridData
 from lodstone import (
     Layout,
+    PlanCoverage,
     Planner,
+    Region,
     ResidentArrays,
     ResidentLease,
+    ResidentTransition,
     ResidentWindow,
     Stream,
     TileKey,
@@ -28,9 +34,49 @@ from .map_data.ome_metadata import OMEZarrFormatError, parse_ome_zarr_metadata, 
 from .map_data.zarr_grid import _apply_omero_display
 
 DEFAULT_GPU_BUDGET = 256 * 1024**2
+DEFAULT_SNAPSHOT_BUDGET = 64 * 1024**2
+DEFAULT_UPLOAD_BUDGET = 64 * 1024**2
+DEFAULT_MAX_FOCUS_DIMENSION = 512
 CAMERA_DEBOUNCE_MS = 180
 LOD_HYSTERESIS = 0.2
 MAX_INITIAL_VOXEL_FOOTPRINT = 4.0
+SLOW_CALLBACK_THRESHOLDS_MS = (16.0, 33.0, 100.0)
+
+
+@dataclass(frozen=True, slots=True)
+class TimingRecord:
+    completed_at: float
+    operation: str
+    duration_ms: float
+    bytes_processed: int
+    request_epoch: int
+    level: int | None
+    roi_shape: tuple[int, ...]
+    channel: int
+    reason: str
+    thread: str
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedPublication:
+    request_epoch: int
+    channel: int
+    level: int
+    region: Region
+    array: np.ndarray
+    transform: np.ndarray
+    coverage: PlanCoverage
+    bytes: int
+    value_range: tuple[float, float] | None
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedResidency:
+    transition: ResidentTransition
+    desired_keys: frozenset[TileKey]
+    request_epoch: int
+    reason: str
 
 
 def _homogeneous_place(place) -> np.ndarray:
@@ -86,12 +132,14 @@ class ChimeraXDispatcher:
             self._callbacks.append(callback)
 
     def _graphics_update(self, *_args) -> None:
-        while True:
-            with self._lock:
-                if not self._callbacks:
-                    return
-                callback = self._callbacks.popleft()
-            callback()
+        # Bound host work to one Lodstone delivery per graphics cycle. A slow
+        # store may extend refinement latency, but it cannot create an
+        # unbounded drain burst immediately after camera debounce.
+        with self._lock:
+            if not self._callbacks:
+                return
+            callback = self._callbacks.popleft()
+        callback()
 
     def close(self) -> None:
         if self._handler is not None:
@@ -113,6 +161,9 @@ class ChimeraXVolumeTarget:
         channel_index: int,
         time_index: int,
         gpu_budget: int,
+        snapshot_budget: int = DEFAULT_SNAPSHOT_BUDGET,
+        upload_budget: int = DEFAULT_UPLOAD_BUDGET,
+        max_focus_dimension: int = DEFAULT_MAX_FOCUS_DIMENSION,
     ) -> None:
         self.owner = owner
         self.session = owner.session
@@ -123,19 +174,33 @@ class ChimeraXVolumeTarget:
         self.channel_index = channel_index
         self.time_index = time_index
         self.gpu_budget = gpu_budget
+        self.snapshot_budget = min(int(snapshot_budget), gpu_budget)
+        self.upload_budget = min(int(upload_budget), gpu_budget)
+        self.max_focus_dimension = int(max_focus_dimension)
         self.max_texture_extent = self._maximum_texture_extent()
         dtypes = [
             np.float32 if level.dtype in (np.dtype(np.float16), np.dtype(np.uint64)) else level.dtype
             for level in source.pyramid.levels
         ]
-        self.resident = ResidentArrays(source.pyramid, dtypes=dtypes, compose=True)
+        self._state_lock = Lock()
+        self._plan_context = {}
+        self._current_request_epoch = 0
+        self.timeline = deque(maxlen=512)
+        self._warning_times = {}
+        self.resident = ResidentArrays(
+            source.pyramid,
+            dtypes=dtypes,
+            compose=True,
+            on_timing=self._resident_timing,
+        )
         self.resources = {}
         self.current_window = None
         self._front_resource = None
         self._back_resources = {}
+        self._pending_publication = None
+        self._publication_context = {}
         self._published_windows = set()
         self._deferred_retired = set()
-        self._value_ranges = {}
 
         # Establish bounds before the first camera-driven plan. This lets the
         # normal ChimeraX open/view logic position the camera around the data.
@@ -150,60 +215,187 @@ class ChimeraXVolumeTarget:
             # remote slabs while ChimeraX progressively fills a dense texture.
             block_shape=None,
             mixed_lod=False,
-            memory_limit=self.gpu_budget,
+            memory_limit=min(
+                self.gpu_budget,
+                self.snapshot_budget,
+                self.upload_budget,
+            ),
             squeeze_hidden=False,
-            max_axis_extent=self.max_texture_extent,
+            max_axis_extent=min(
+                value
+                for value in (
+                    self.max_texture_extent,
+                    self.max_focus_dimension,
+                )
+                if value is not None
+            ),
         )
 
-    def prepare(self, view, plan):
+    def register_plan(self, plan, request_epoch: int, reason: str) -> None:
+        with self._state_lock:
+            self._current_request_epoch = request_epoch
+            self._plan_context[id(plan)] = (request_epoch, reason)
+            if len(self._plan_context) > 16:
+                oldest = next(iter(self._plan_context))
+                self._plan_context.pop(oldest, None)
+
+    def stage_prepare(self, view, plan) -> PreparedResidency:
+        request_epoch, reason = self._context(plan)
+        started = perf_counter()
         transition = self.resident.prepare(plan)
+        self._record_timing(
+            "ResidentArrays.prepare",
+            started,
+            sum(window.nbytes for window in transition.prepared),
+            request_epoch,
+            plan.target_level,
+            self._plan_shape(plan),
+            reason,
+            "cpu",
+        )
+        desired = plan.desired or plan.wanted
+        return PreparedResidency(
+            transition,
+            frozenset(tile.key for tile in desired),
+            request_epoch,
+            reason,
+        )
+
+    def prepare(self, view, plan, prepared: PreparedResidency):
+        started = perf_counter()
+        if prepared.request_epoch != self._current_request_epoch:
+            return None
+        transition = prepared.transition
         for window in transition.retired:
             if window is self.current_window:
                 self._deferred_retired.add(window)
             else:
                 self._retire_window(window)
-        for window in transition.prepared:
-            self._ensure_window(window)
         if self.current_window is None:
-            fallback = self.resident.active.get(plan.target_level)
+            with self.resident.lock:
+                fallback = self.resident.active.get(plan.target_level)
             if fallback is not None:
                 self._show_window(fallback)
             elif self._bounds_resource is not None:
                 self._bounds_resource[2].display = self._channel_active()
-        desired = plan.desired or plan.wanted
-        return ResidentLease(self.resident, frozenset(tile.key for tile in desired))
+        self._record_timing(
+            "target.prepare",
+            started,
+            0,
+            prepared.request_epoch,
+            plan.target_level,
+            self._plan_shape(plan),
+            prepared.reason,
+            "graphics",
+        )
+        return ResidentLease(self.resident, prepared.desired_keys)
 
-    def apply(self, updates: Sequence[Update]) -> None:
-        # ResidentArrays is mutable target state. Keep its writes behind
-        # Stream's stale-generation check on the ChimeraX thread.
+    def stage(self, updates: Sequence[Update]):
+        started = perf_counter()
         changes = self.resident.apply(updates)
-        for change in changes:
-            buffer, _grid, _volume = self._ensure_window(change.window)
-            for region in change.regions:
-                self._observe_values(
-                    change.window,
-                    self._buffer_region(buffer, change.window, region),
-                )
+        request_epoch = self._current_request_epoch
+        self._record_timing(
+            "ResidentArrays.apply",
+            started,
+            sum(update.data.nbytes for update in updates),
+            request_epoch,
+            updates[0].level if updates else None,
+            updates[0].region.shape if updates else (),
+            "stream-update",
+            "cpu",
+        )
+        return changes
 
-    def phase_complete(self, view, plan, phase: int) -> None:
+    def apply(self, changes) -> None:
+        started = perf_counter()
+        # All dense writes, composition, and value inspection have already
+        # completed on Lodstone's runtime thread. The host callback is a
+        # deliberately cheap stale-checked handoff.
+        self._record_timing(
+            "target.apply",
+            started,
+            0,
+            self._current_request_epoch,
+            changes[0].window.level if changes else None,
+            changes[0].window.region.shape if changes else (),
+            "stream-update",
+            "graphics",
+        )
+
+    def stage_phase(self, view, plan, phase: int):
+        request_epoch, reason = self._context(plan)
+        publications = []
         levels = {tile.level for tile in plan.desired if tile.phase == phase}
-        for level in sorted(levels):
-            window = self.resident.windows.get(level)
-            if window is not None and window.key_regions:
-                buffer, _grid, old_volume = self._ensure_window(window)
-                _snapshot, grid, volume = self._create_volume(
-                    buffer.copy(),
-                    window.level,
-                    tuple(window.region.start[axis] for axis in self.displayed_axes),
+        with self.resident.lock:
+            for level in sorted(levels):
+                window = self.resident.windows.get(level)
+                if window is None or not window.key_regions:
+                    continue
+                started = perf_counter()
+                array, region = self._bounded_snapshot(window)
+                value_range = None
+                if array.size:
+                    value_range = (float(np.min(array)), float(np.max(array)))
+                transform = np.array(window.transform, copy=True)
+                transform.setflags(write=False)
+                publications.append(
+                    PreparedPublication(
+                        request_epoch=request_epoch,
+                        channel=self.channel_index,
+                        level=window.level,
+                        region=region,
+                        array=array,
+                        transform=transform,
+                        coverage=plan.coverage,
+                        bytes=array.nbytes,
+                        value_range=value_range,
+                        reason=reason,
+                    ),
                 )
-                # Keep observing Lodstone's mutable resident array, but expose
-                # only the completed immutable snapshot to ChimeraX.
-                self.resources[window] = (buffer, grid, volume)
-                if not self._is_front_volume(old_volume):
-                    self._delete_volume(old_volume)
-                self._link_channel_volumes(window.level)
-                self._update_thresholds(window)
-                self._schedule_snapshot_publish(window, volume)
+                self._record_timing(
+                    "snapshot_copy_and_range",
+                    started,
+                    array.nbytes,
+                    request_epoch,
+                    window.level,
+                    region.shape,
+                    reason,
+                    "cpu",
+                )
+        return tuple(publications)
+
+    def phase_complete(self, view, plan, phase: int, publications) -> None:
+        for publication in publications:
+            if publication.request_epoch != self._current_request_epoch or getattr(self.owner, "deleted", False):
+                continue
+            started = perf_counter()
+            window = self._publication_window(publication.level)
+            if window is None:
+                continue
+            old_resource = self.resources.get(window)
+            _snapshot, grid, volume = self._create_volume(
+                publication.array,
+                publication.level,
+                tuple(publication.region.start[axis] for axis in self.displayed_axes),
+                request_epoch=publication.request_epoch,
+                reason=publication.reason,
+            )
+            self.resources[window] = (publication.array, grid, volume)
+            if old_resource is not None and not self._is_front_volume(old_resource[2]):
+                self._timed_delete(old_resource[2], publication)
+            self._link_channel_volumes(publication.level)
+            self._update_thresholds(window, publication.value_range)
+            self._schedule_snapshot_publish(window, volume, publication)
+            self._record_timing(
+                "phase_complete",
+                started,
+                publication.bytes,
+                publication.request_epoch,
+                publication.level,
+                publication.region.shape,
+                publication.reason,
+                "graphics",
+            )
 
     def _maximum_texture_extent(self):
         render = getattr(getattr(self.session, "main_view", None), "render", None)
@@ -214,6 +406,125 @@ class ChimeraXVolumeTarget:
             return int(render.max_3d_texture_size())
         except (AttributeError, RuntimeError, ValueError):
             return None
+
+    def _context(self, plan) -> tuple[int, str]:
+        with self._state_lock:
+            return self._plan_context.get(id(plan), (self._current_request_epoch, "unspecified"))
+
+    @staticmethod
+    def _plan_shape(plan) -> tuple[int, ...]:
+        tiles = plan.desired or plan.wanted
+        if not tiles:
+            return ()
+        start = [min(tile.region.start[axis] for tile in tiles) for axis in range(tiles[0].region.ndim)]
+        stop = [max(tile.region.stop[axis] for tile in tiles) for axis in range(tiles[0].region.ndim)]
+        return tuple(end - begin for begin, end in zip(start, stop, strict=True))
+
+    def _resident_timing(
+        self,
+        operation: str,
+        duration: float,
+        bytes_processed: int,
+        level: int,
+        region: Region,
+    ) -> None:
+        request_epoch = self._current_request_epoch
+        self._record_duration(
+            operation,
+            duration,
+            bytes_processed,
+            request_epoch,
+            level,
+            region.shape,
+            "resident",
+            "cpu",
+        )
+
+    def _record_timing(
+        self,
+        operation: str,
+        started: float,
+        bytes_processed: int,
+        request_epoch: int,
+        level: int | None,
+        roi_shape: tuple[int, ...],
+        reason: str,
+        thread: str,
+    ) -> None:
+        self._record_duration(
+            operation,
+            perf_counter() - started,
+            bytes_processed,
+            request_epoch,
+            level,
+            roi_shape,
+            reason,
+            thread,
+        )
+
+    def _record_duration(
+        self,
+        operation: str,
+        duration: float,
+        bytes_processed: int,
+        request_epoch: int,
+        level: int | None,
+        roi_shape: tuple[int, ...],
+        reason: str,
+        thread: str,
+    ) -> None:
+        record = TimingRecord(
+            perf_counter(),
+            operation,
+            duration * 1000.0,
+            int(bytes_processed),
+            request_epoch,
+            level,
+            tuple(int(value) for value in roi_shape),
+            self.channel_index,
+            reason,
+            thread,
+        )
+        with self._state_lock:
+            self.timeline.append(record)
+            crossed = [threshold for threshold in SLOW_CALLBACK_THRESHOLDS_MS if record.duration_ms >= threshold]
+            threshold = crossed[-1] if crossed else None
+            now = perf_counter()
+            warning_key = (operation, threshold)
+            last_warning = self._warning_times.get(warning_key, 0.0)
+            should_warn = thread == "graphics" and threshold is not None and now - last_warning >= 5.0
+            if should_warn:
+                self._warning_times[warning_key] = now
+        if should_warn:
+            self.session.logger.warning(
+                f"Lodstone slow graphics callback: {operation} "  # noqa: G004
+                f"{record.duration_ms:.1f} ms, {record.bytes_processed / 1024**2:.1f} MiB, "
+                f"epoch {request_epoch}, level {level}, roi {record.roi_shape}, "
+                f"channel {self.channel_index}, reason {reason}",
+            )
+
+    def _bounded_snapshot(self, window: ResidentWindow) -> tuple[np.ndarray, Region]:
+        selection = tuple(slice(None) if axis in self.displayed_axes else 0 for axis in range(window.region.ndim))
+        spatial = window.data[selection]
+        shape = [min(int(size), self.max_focus_dimension) for size in spatial.shape]
+        byte_limit = min(self.snapshot_budget, self.upload_budget)
+        while int(np.prod(shape)) * spatial.dtype.itemsize > byte_limit:
+            axis = int(np.argmax(shape))
+            shape[axis] = max(1, shape[axis] // 2)
+        starts = [(size - kept) // 2 for size, kept in zip(spatial.shape, shape, strict=True)]
+        slices = tuple(slice(start, start + kept) for start, kept in zip(starts, shape, strict=True))
+        snapshot = np.array(spatial[slices], copy=True)
+        snapshot.setflags(write=False)
+        region_start = list(window.region.start)
+        region_stop = list(window.region.stop)
+        for spatial_axis, data_axis in enumerate(self.displayed_axes):
+            region_start[data_axis] += starts[spatial_axis]
+            region_stop[data_axis] = region_start[data_axis] + shape[spatial_axis]
+        return snapshot, Region(tuple(region_start), tuple(region_stop))
+
+    def _publication_window(self, level: int):
+        with self.resident.lock:
+            return self.resident.windows.get(level)
 
     def _buffer_region(self, buffer, window: ResidentWindow, region):
         slices = tuple(
@@ -229,13 +540,15 @@ class ChimeraXVolumeTarget:
         self.resident.discard(keys)
 
     def complete(self, view, plan) -> None:
+        started = perf_counter()
         transition = self.resident.complete(plan)
         for window in transition.retired:
             if window is self.current_window:
                 self._deferred_retired.add(window)
             else:
                 self._retire_window(window)
-        target = self.resident.active.get(plan.target_level)
+        with self.resident.lock:
+            target = self.resident.active.get(plan.target_level)
         if target is not None:
             presenter = getattr(self.owner, "present_lodstone_level", None)
             if presenter is None:
@@ -246,6 +559,17 @@ class ChimeraXVolumeTarget:
         if self._bounds_resource is not None:
             self._delete_volume(self._bounds_resource[2])
             self._bounds_resource = None
+        request_epoch, reason = self._context(plan)
+        self._record_timing(
+            "target.complete",
+            started,
+            0,
+            request_epoch,
+            plan.target_level,
+            self._plan_shape(plan),
+            reason,
+            "graphics",
+        )
 
     def redraw(self) -> None:
         self.session.main_view.redraw_needed = True
@@ -284,7 +608,10 @@ class ChimeraXVolumeTarget:
         spatial_start,
         *,
         step_scale=None,
+        request_epoch: int = 0,
+        reason: str = "bounds",
     ):
+        started = perf_counter()
         dataset = self.metadata.multiscales.datasets[level]
         step, origin = spatial_transform_angstrom(self.metadata.multiscales, dataset)
         if step_scale is not None:
@@ -320,6 +647,16 @@ class ChimeraXVolumeTarget:
         )
         volume.display = False
         self.owner.add([volume])
+        self._record_timing(
+            "_create_volume",
+            started,
+            buffer.nbytes,
+            request_epoch,
+            level,
+            buffer.shape,
+            reason,
+            "graphics",
+        )
         return buffer, grid, volume
 
     def _link_channel_volumes(self, level: int) -> None:
@@ -334,24 +671,57 @@ class ChimeraXVolumeTarget:
 
             MapChannels(sorted(volumes, key=lambda volume: volume.data.channel))
 
-    def _schedule_snapshot_publish(self, window: ResidentWindow, volume) -> None:
+    def _schedule_snapshot_publish(
+        self,
+        window: ResidentWindow,
+        volume,
+        publication: PreparedPublication,
+    ) -> None:
+        previous_pending = self._pending_publication
+        if previous_pending is not None and previous_pending[1] is not volume:
+            self._delete_volume(previous_pending[1])
+        token = object()
+        self._pending_publication = (token, volume)
+        self._publication_context[volume] = publication
+
         def publish() -> None:
+            if self._pending_publication != (token, volume):
+                return
+            self._pending_publication = None
+            if publication.request_epoch != self._current_request_epoch:
+                if not volume.deleted:
+                    self._timed_delete(volume, publication)
+                return
             resource = self.resources.get(window)
             if volume.deleted or resource is None or resource[2] is not volume:
                 return
             # Texture creation during a graphics-update trigger can disturb
             # that frame on older ChimeraX Dailies. Run between frames instead.
+            started = perf_counter()
             volume.update_drawings()
+            self._record_timing(
+                "volume.update_drawings",
+                started,
+                publication.bytes,
+                publication.request_epoch,
+                publication.level,
+                publication.region.shape,
+                publication.reason,
+                "graphics",
+            )
             previous = self._back_resources.get(window.level)
             if previous is not None and previous[1][2] is not volume:
-                self._delete_volume(previous[1][2])
+                self._timed_delete(previous[1][2], publication)
             self._back_resources[window.level] = (window, resource)
             self._published_windows.add(window)
             presenter = getattr(self.owner, "present_lodstone_level", None)
             if presenter is None:
-                retired = self._activate_back(window.level)
+                retired = self._activate_back_timed(window.level)
                 if retired is not None:
-                    self._delete_volume(retired[2])
+                    self._timed_delete(
+                        retired[2],
+                        self._publication_context.get(retired[2], publication),
+                    )
             else:
                 presenter(window.level)
             self.session.main_view.redraw_needed = True
@@ -364,8 +734,41 @@ class ChimeraXVolumeTarget:
         timers.append(ui.timer(0, publish))
         self.session._lodstone_publish_timers = timers
 
+    def _timed_delete(self, volume, publication: PreparedPublication) -> None:
+        started = perf_counter()
+        self._delete_volume(volume)
+        self._publication_context.pop(volume, None)
+        self._record_timing(
+            "old_volume_deletion",
+            started,
+            publication.bytes,
+            publication.request_epoch,
+            publication.level,
+            publication.region.shape,
+            publication.reason,
+            "graphics",
+        )
+
+    def _activate_back_timed(self, level: int):
+        candidate = self._back_resources.get(level)
+        publication = None if candidate is None else self._publication_context.get(candidate[1][2])
+        started = perf_counter()
+        retired = self._activate_back(level)
+        if publication is not None:
+            self._record_timing(
+                "front_back_activation",
+                started,
+                publication.bytes,
+                publication.request_epoch,
+                publication.level,
+                publication.region.shape,
+                publication.reason,
+                "graphics",
+            )
+        return retired
+
     def _show_window(self, window: ResidentWindow) -> None:
-        retired = self._activate_back(window.level)
+        retired = self._activate_back_timed(window.level)
         if retired is not None:
             self._delete_volume(retired[2])
             return
@@ -412,7 +815,6 @@ class ChimeraXVolumeTarget:
             if candidate[0] is window:
                 self._back_resources.pop(level, None)
         self._published_windows.discard(window)
-        self._value_ranges.pop(window, None)
         if resource is not None and not self._is_front_volume(resource[2]):
             self._delete_volume(resource[2])
         if self.current_window is window:
@@ -443,18 +845,11 @@ class ChimeraXVolumeTarget:
             return omero.channels[self.channel_index].active
         return self.time_index == 0
 
-    def _observe_values(self, window: ResidentWindow, values: np.ndarray) -> None:
-        if values.size == 0:
-            return
-        minimum = float(np.min(values))
-        maximum = float(np.max(values))
-        previous = self._value_ranges.get(window)
-        self._value_ranges[window] = (
-            minimum if previous is None else min(previous[0], minimum),
-            maximum if previous is None else max(previous[1], maximum),
-        )
-
-    def _update_thresholds(self, window: ResidentWindow) -> None:
+    def _update_thresholds(
+        self,
+        window: ResidentWindow,
+        value_range: tuple[float, float] | None,
+    ) -> None:
         volume = self.resources[window][2]
         omero = self.metadata.omero
         if omero and self.channel_index < len(omero.channels):
@@ -467,7 +862,6 @@ class ChimeraXVolumeTarget:
                     ],
                 )
                 return
-        value_range = self._value_ranges.get(window)
         if value_range is not None and value_range[1] > value_range[0]:
             volume.set_parameters(image_levels=[(value_range[0], 0.0), (value_range[1], 1.0)])
 
@@ -496,6 +890,11 @@ class LodstoneVolumeController:
         self._active_coverage = None
         self._pending_view = None
         self._debounce_timer = None
+        self._request_epoch = 0
+        self._planning_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="lodstone-plan",
+        )
         self.stream = Stream(
             source,
             target,
@@ -525,7 +924,7 @@ class LodstoneVolumeController:
             return
         self._signature = signature
         if self._target_level is None:
-            self._submit_view(view)
+            self._submit_view(view, reason="initial")
             return
 
         self._pending_view = view
@@ -543,14 +942,55 @@ class LodstoneVolumeController:
         self._pending_view = None
         self._debounce_timer = None
         if view is not None and not self.owner.deleted:
-            self._submit_view(view)
+            self._submit_view(view, reason="settled")
 
-    def _submit_view(self, view: View) -> None:
-        plan = self.stream.plan(
-            view,
-            previous_target_level=self._target_level,
-            lod_hysteresis=LOD_HYSTERESIS,
-        )
+    def _submit_view(self, view: View, *, reason: str) -> None:
+        self._request_epoch += 1
+        request_epoch = self._request_epoch
+        previous_target_level = self._target_level
+
+        def calculate():
+            started = perf_counter()
+            plan = self.stream.plan(
+                view,
+                previous_target_level=previous_target_level,
+                lod_hysteresis=LOD_HYSTERESIS,
+            )
+            self.target._record_timing(
+                "stream.plan",
+                started,
+                0,
+                request_epoch,
+                plan.target_level,
+                self.target._plan_shape(plan),
+                reason,
+                "cpu",
+            )
+            return plan
+
+        future = self._planning_executor.submit(calculate)
+
+        def planned(done) -> None:
+            try:
+                plan = done.result()
+            except Exception as error:  # noqa: BLE001
+                self.dispatcher(
+                    lambda error=error: self.session.logger.warning(
+                        f"Lodstone {self.target.name} planning failed: {error}",  # noqa: G004
+                    ),
+                )
+                return
+
+            def submit() -> None:
+                self._submit_planned(view, plan, request_epoch, reason)
+
+            self.dispatcher(submit)
+
+        future.add_done_callback(planned)
+
+    def _submit_planned(self, view, plan, request_epoch: int, reason: str) -> None:
+        if request_epoch != self._request_epoch or self.owner.deleted:
+            return
         if not plan.desired:
             self.session.logger.status(
                 f"Lodstone {self.target.name}: waiting for a valid fitted view",
@@ -559,6 +999,7 @@ class LodstoneVolumeController:
             return
         if plan.coverage == self._active_coverage:
             return
+        self.target.register_plan(plan, request_epoch, reason)
         self._target_level = plan.target_level
         self.stream.submit(view, plan)
         self._active_coverage = plan.coverage
@@ -632,6 +1073,7 @@ class LodstoneVolumeController:
             self._handler = None
         self._disconnect_status()
         self.stream.close()
+        self._planning_executor.shutdown(wait=False, cancel_futures=True)
 
 
 class LodstoneZarrModel(Model):
@@ -698,6 +1140,25 @@ class LodstoneZarrModel(Model):
     def scales(self):
         return [dataset.path for dataset in self.ome_zarr_metadata.multiscales.datasets]
 
+    @property
+    def lodstone_timeline(self) -> tuple[TimingRecord, ...]:
+        """Completed CPU and graphics boundaries in chronological order."""
+        return tuple(
+            sorted(
+                (record for controller in self.controllers for record in controller.target.timeline),
+                key=lambda record: record.completed_at,
+            ),
+        )
+
+    @property
+    def longest_graphics_callback(self) -> TimingRecord | None:
+        """The slowest measured renderer-owned operation so far."""
+        return max(
+            (record for record in self.lodstone_timeline if record.thread == "graphics"),
+            key=lambda record: record.duration_ms,
+            default=None,
+        )
+
     def present_lodstone_level(self, level: int) -> None:
         candidates = []
         for controller in self.controllers:
@@ -707,14 +1168,26 @@ class LodstoneZarrModel(Model):
             candidates.append((controller.target, candidate[0]))
         retired = []
         for target, _window in candidates:
-            old = target._activate_back(level)
+            activate = getattr(target, "_activate_back_timed", None)
+            old = target._activate_back(level) if activate is None else activate(level)
             if old is not None:
                 retired.append((target, old))
+
         # Every new channel is selected before any old front is destroyed.
-        for target, resource in retired:
-            target._delete_volume(resource[2])
-        for target, _window in candidates:
-            target._flush_deferred_retired()
+        # ChimeraX has no public texture-upload completion fence. Retain the
+        # old fronts through the next graphics update as a frame-ack
+        # workaround, then retire them in one bounded dispatcher callback.
+        def retire_previous_fronts() -> None:
+            for target, resource in retired:
+                publication = getattr(target, "_publication_context", {}).get(resource[2])
+                if publication is None:
+                    target._delete_volume(resource[2])
+                else:
+                    target._timed_delete(resource[2], publication)
+            for target, _window in candidates:
+                target._flush_deferred_retired()
+
+        self.dispatcher(retire_previous_fronts)
         self.session.main_view.redraw_needed = True
 
     def delete(self) -> None:

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -26,7 +26,7 @@ from .map_data.constants import UNITFACTOR
 from .map_data.ome_metadata import OMEZarrFormatError, parse_ome_zarr_metadata, spatial_transform_angstrom
 from .map_data.zarr_grid import _apply_omero_display
 
-DEFAULT_GPU_BUDGET = 512 * 1024**2
+DEFAULT_GPU_BUDGET = 256 * 1024**2
 
 
 def _update_volume_now(volume) -> None:
@@ -70,7 +70,7 @@ def _upload_texture_3d(texture, data: np.ndarray, offset_zyx) -> None:
         gl.glBindTexture(target, 0)
 
 
-def _patch_volume_texture(volume, buffer, window, updates, displayed_axes) -> bool:
+def _patch_volume_texture(volume, buffer, window, regions, displayed_axes) -> bool:
     """Patch an existing scalar 3D texture, returning false when unsafe."""
 
     if buffer.ndim != 3:
@@ -100,9 +100,10 @@ def _patch_volume_texture(volume, buffer, window, updates, displayed_axes) -> bo
         return False
 
     patches = []
-    for update in updates:
-        starts = tuple(update.region.start[axis] - window.region.start[axis] for axis in displayed_axes)
-        stops = tuple(update.region.stop[axis] - window.region.start[axis] for axis in displayed_axes)
+    for item in regions:
+        region = getattr(item, "region", item)
+        starts = tuple(region.start[axis] - window.region.start[axis] for axis in displayed_axes)
+        stops = tuple(region.stop[axis] - window.region.start[axis] for axis in displayed_axes)
         if any(
             start < 0 or stop > size or stop <= start
             for start, stop, size in zip(starts, stops, buffer.shape, strict=True)
@@ -207,11 +208,12 @@ class ChimeraXVolumeTarget:
         self.channel_index = channel_index
         self.time_index = time_index
         self.gpu_budget = gpu_budget
+        self.max_texture_extent = self._maximum_texture_extent()
         dtypes = [
             np.float32 if level.dtype in (np.dtype(np.float16), np.dtype(np.uint64)) else level.dtype
             for level in source.pyramid.levels
         ]
-        self.resident = ResidentArrays(source.pyramid, dtypes=dtypes)
+        self.resident = ResidentArrays(source.pyramid, dtypes=dtypes, compose=True)
         self.resources = {}
         self.current_window = None
         self._value_ranges = {}
@@ -231,6 +233,7 @@ class ChimeraXVolumeTarget:
             mixed_lod=False,
             memory_limit=self.gpu_budget,
             squeeze_hidden=False,
+            max_axis_extent=self.max_texture_extent,
         )
 
     def prepare(self, view, plan) -> None:
@@ -246,23 +249,60 @@ class ChimeraXVolumeTarget:
             elif self._bounds_resource is not None:
                 self._bounds_resource[2].display = self._channel_active()
 
-    def apply(self, updates: Sequence[Update]) -> None:
-        changes = self.resident.apply(updates)
+    def stage(self, updates: Sequence[Update]):
+        """Write, convert, and compose resident arrays off the graphics thread."""
+
+        return self.resident.apply(updates)
+
+    def apply(self, staged) -> None:
+        if staged and isinstance(staged[0], Update):
+            staged = self.stage(staged)
+        changes = staged
         for change in changes:
             buffer, grid, volume = self._ensure_window(change.window)
-            for update in change.updates:
-                self._observe_values(change.window, update.data)
+            for region in change.regions:
+                self._observe_values(
+                    change.window,
+                    self._buffer_region(buffer, change.window, region),
+                )
             self._update_thresholds(change.window)
             if not _patch_volume_texture(
                 volume,
                 buffer,
                 change.window,
-                change.updates,
+                change.regions,
                 self.displayed_axes,
             ):
                 grid.values_changed()
             _update_volume_now(volume)
             self._show_window(change.window)
+
+    def phase_complete(self, view, plan, phase: int) -> None:
+        levels = {tile.level for tile in plan.desired if tile.phase == phase}
+        for level in sorted(levels):
+            window = self.resident.windows.get(level)
+            if window is not None and window.key_regions:
+                self._show_window(window)
+
+    def _maximum_texture_extent(self):
+        render = getattr(getattr(self.session, "main_view", None), "render", None)
+        if render is None:
+            return None
+        try:
+            render.make_current()
+            return int(render.max_3d_texture_size())
+        except (AttributeError, RuntimeError, ValueError):
+            return None
+
+    def _buffer_region(self, buffer, window: ResidentWindow, region):
+        slices = tuple(
+            slice(
+                region.start[axis] - window.region.start[axis],
+                region.stop[axis] - window.region.start[axis],
+            )
+            for axis in self.displayed_axes
+        )
+        return buffer[slices]
 
     def discard(self, keys: Collection[TileKey]) -> None:
         self.resident.discard(keys)
@@ -436,14 +476,20 @@ class LodstoneVolumeController:
             planner=Planner(progressive=True),
             dispatch=dispatcher,
             workers=8,
-            cpu_cache=2 * 1024**3,
-            inflight=256 * 1024**2,
+            cpu_cache=max(2 * target.gpu_budget, 256 * 1024**2),
+            inflight=min(target.gpu_budget, 128 * 1024**2),
             batch_size=8,
         )
         self._disconnect_status = self.stream.on_status_changed(self._status_changed)
         self._handler = self.session.triggers.add_handler("graphics update", self._graphics_update)
 
     def _graphics_update(self, *_args) -> None:
+        # The open command constructs the model before adding it to the
+        # session and fitting the camera to its bounds. Planning against that
+        # transient camera can request an unnecessarily fine full volume and
+        # delay creation of the main window.
+        if self.owner.id is None:
+            return
         view, signature = self._view()
         if self._signature is not None and np.allclose(signature, self._signature, rtol=1e-7, atol=1e-7):
             return
@@ -515,6 +561,8 @@ class LodstoneZarrModel(Model):
         gpu_budget: int = DEFAULT_GPU_BUDGET,
     ) -> None:
         super().__init__(name, session)
+        self.dispatcher = None
+        self.controllers = []
         self.group = group
         self.ome_zarr_metadata = metadata = parse_ome_zarr_metadata(group)
         self.source = source_from_group(group, metadata)
@@ -526,9 +574,13 @@ class LodstoneZarrModel(Model):
         finest_shape = self.source.pyramid.levels[0].shape
         time_count = finest_shape[time_axis] if time_axis is not None else 1
         channel_count = finest_shape[channel_axis] if channel_axis is not None else 1
+        if time_count > 1:
+            raise OMEZarrFormatError(
+                "Lodstone streaming does not yet support switching timepoints; "
+                "open this time series without 'streaming true'.",
+            )
 
         self.dispatcher = ChimeraXDispatcher(session)
-        self.controllers = []
         for time_index in range(time_count):
             for channel_index in range(channel_count):
                 index = [None] * len(multiscales.axes)
@@ -564,5 +616,6 @@ class LodstoneZarrModel(Model):
     def delete(self) -> None:
         for controller in self.controllers:
             controller.close()
-        self.dispatcher.close()
+        if self.dispatcher is not None:
+            self.dispatcher.close()
         super().delete()

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -264,7 +264,6 @@ class ChimeraXVolumeTarget:
                 self.displayed_axes,
             ):
                 grid.values_changed()
-            self._show_window(change.window)
 
     def phase_complete(self, view, plan, phase: int) -> None:
         levels = {tile.level for tile in plan.desired if tile.phase == phase}
@@ -483,7 +482,7 @@ class LodstoneVolumeController:
         self._signature = signature
         plan = self.stream.update(view)
         message = f"Lodstone {self.target.name}: loading {len(plan.wanted)} blocks toward level {plan.target_level}"
-        self.session.logger.info(message)
+        self.session.logger.status(message, blank_after=3)
 
     def _status_changed(self, status) -> None:
         if status.state == "failed":

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -212,9 +212,9 @@ class ChimeraXVolumeTarget:
     def layout(self, view, pyramid) -> Layout:
         return Layout(
             kind="dense",
-            # Matching native chunks avoids repeatedly assembling overlapping
-            # remote slabs while ChimeraX progressively fills a dense texture.
-            block_shape=None,
+            # Logical focus blocks remain small while Stream's native-chunk
+            # cache coalesces the larger underlying Zarr chunk reads.
+            block_shape=(64, 128, 128),
             mixed_lod=False,
             memory_limit=min(
                 self.gpu_budget,
@@ -230,6 +230,7 @@ class ChimeraXVolumeTarget:
                 )
                 if value is not None
             ),
+            memory_policy="crop",
         )
 
     def register_plan(self, plan, request_epoch: int, reason: str) -> None:
@@ -1019,7 +1020,7 @@ class LodstoneVolumeController:
         self.stream.submit(view, plan)
         self._active_coverage = plan.coverage
         message = f"Lodstone {self.target.name}: loading {len(plan.wanted)} blocks toward level {plan.target_level}"
-        self.session.logger.status(message, blank_after=3)
+        self.session.logger.status(message)
 
     def _status_changed(self, status) -> None:
         if status.state == "failed":
@@ -1028,8 +1029,14 @@ class LodstoneVolumeController:
             )
         elif status.state == "complete":
             mib = status.bytes_read / 1024**2
-            message = f"Lodstone {self.target.name}: level ready ({status.resident} blocks, {mib:.1f} MiB read)"
+            active = None if self.target.current_window is None else self.target.current_window.level
+            message = (
+                f"Lodstone {self.target.name}: active L{active}, "
+                f"target L{self._target_level} "
+                f"({status.resident} blocks, {mib:.1f} MiB read)"
+            )
             self.session.logger.info(message)
+            self.session.logger.status(message)
 
     def _view(self):
         main_view = self.session.main_view

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -14,6 +14,7 @@ from lodstone import (
     Layout,
     Planner,
     ResidentArrays,
+    ResidentLease,
     ResidentWindow,
     Stream,
     TileKey,
@@ -130,6 +131,8 @@ class ChimeraXVolumeTarget:
         self.resident = ResidentArrays(source.pyramid, dtypes=dtypes, compose=True)
         self.resources = {}
         self.current_window = None
+        self._front_resource = None
+        self._back_resources = {}
         self._published_windows = set()
         self._deferred_retired = set()
         self._value_ranges = {}
@@ -152,7 +155,7 @@ class ChimeraXVolumeTarget:
             max_axis_extent=self.max_texture_extent,
         )
 
-    def prepare(self, view, plan) -> None:
+    def prepare(self, view, plan):
         transition = self.resident.prepare(plan)
         for window in transition.retired:
             if window is self.current_window:
@@ -167,6 +170,8 @@ class ChimeraXVolumeTarget:
                 self._show_window(fallback)
             elif self._bounds_resource is not None:
                 self._bounds_resource[2].display = self._channel_active()
+        desired = plan.desired or plan.wanted
+        return ResidentLease(self.resident, frozenset(tile.key for tile in desired))
 
     def apply(self, updates: Sequence[Update]) -> None:
         # ResidentArrays is mutable target state. Keep its writes behind
@@ -186,7 +191,6 @@ class ChimeraXVolumeTarget:
             window = self.resident.windows.get(level)
             if window is not None and window.key_regions:
                 buffer, _grid, old_volume = self._ensure_window(window)
-                self._delete_volume(old_volume)
                 _snapshot, grid, volume = self._create_volume(
                     buffer.copy(),
                     window.level,
@@ -195,6 +199,8 @@ class ChimeraXVolumeTarget:
                 # Keep observing Lodstone's mutable resident array, but expose
                 # only the completed immutable snapshot to ChimeraX.
                 self.resources[window] = (buffer, grid, volume)
+                if not self._is_front_volume(old_volume):
+                    self._delete_volume(old_volume)
                 self._link_channel_volumes(window.level)
                 self._update_thresholds(window)
                 self._schedule_snapshot_publish(window, volume)
@@ -336,10 +342,16 @@ class ChimeraXVolumeTarget:
             # Texture creation during a graphics-update trigger can disturb
             # that frame on older ChimeraX Dailies. Run between frames instead.
             volume.update_drawings()
+            previous = self._back_resources.get(window.level)
+            if previous is not None and previous[1][2] is not volume:
+                self._delete_volume(previous[1][2])
+            self._back_resources[window.level] = (window, resource)
             self._published_windows.add(window)
             presenter = getattr(self.owner, "present_lodstone_level", None)
             if presenter is None:
-                self._show_window(window)
+                retired = self._activate_back(window.level)
+                if retired is not None:
+                    self._delete_volume(retired[2])
             else:
                 presenter(window.level)
             self.session.main_view.redraw_needed = True
@@ -353,7 +365,12 @@ class ChimeraXVolumeTarget:
         self.session._lodstone_publish_timers = timers
 
     def _show_window(self, window: ResidentWindow) -> None:
-        if self.current_window is window:
+        retired = self._activate_back(window.level)
+        if retired is not None:
+            self._delete_volume(retired[2])
+            return
+        resource = self.resources.get(window)
+        if resource is None or self._front_resource == (window, resource):
             return
         active = self._channel_active()
         if self._bounds_resource is not None:
@@ -365,15 +382,42 @@ class ChimeraXVolumeTarget:
         for existing, (_buffer, _grid, volume) in self.resources.items():
             volume.display = active and existing is window
         self.current_window = window
+        self._front_resource = (window, resource)
+
+    def _activate_back(self, level: int):
+        """Atomically select an initialized back buffer, returning the old front."""
+
+        candidate = self._back_resources.pop(level, None)
+        if candidate is None:
+            return None
+        window, resource = candidate
+        old = None if self._front_resource is None else self._front_resource[1]
+        active = self._channel_active()
+        resource[2].display = active
+        if old is not None and old is not resource:
+            old[2].display = False
+        if self._bounds_resource is not None:
+            self._delete_volume(self._bounds_resource[2])
+            self._bounds_resource = None
+        self.current_window = window
+        self._front_resource = candidate
+        return old if old is not resource else None
+
+    def _is_front_volume(self, volume) -> bool:
+        return self._front_resource is not None and self._front_resource[1][2] is volume
 
     def _retire_window(self, window: ResidentWindow) -> None:
         resource = self.resources.pop(window, None)
+        for level, candidate in tuple(self._back_resources.items()):
+            if candidate[0] is window:
+                self._back_resources.pop(level, None)
         self._published_windows.discard(window)
         self._value_ranges.pop(window, None)
-        if resource is not None:
+        if resource is not None and not self._is_front_volume(resource[2]):
             self._delete_volume(resource[2])
         if self.current_window is window:
             self.current_window = None
+            self._front_resource = None
 
     def _flush_deferred_retired(self) -> None:
         for window in tuple(self._deferred_retired):
@@ -655,15 +699,21 @@ class LodstoneZarrModel(Model):
         return [dataset.path for dataset in self.ome_zarr_metadata.multiscales.datasets]
 
     def present_lodstone_level(self, level: int) -> None:
-        windows = []
+        candidates = []
         for controller in self.controllers:
-            window = controller.target.resident.windows.get(level)
-            if window is None or window not in controller.target._published_windows:
+            candidate = controller.target._back_resources.get(level)
+            if candidate is None:
                 return
-            windows.append((controller.target, window))
-        for target, window in windows:
-            target._show_window(window)
-        for target, _window in windows:
+            candidates.append((controller.target, candidate[0]))
+        retired = []
+        for target, _window in candidates:
+            old = target._activate_back(level)
+            if old is not None:
+                retired.append((target, old))
+        # Every new channel is selected before any old front is destroyed.
+        for target, resource in retired:
+            target._delete_volume(resource[2])
+        for target, _window in candidates:
             target._flush_deferred_retired()
         self.session.main_view.redraw_needed = True
 

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -1,0 +1,428 @@
+"""Lodstone streaming adapter for ChimeraX volume rendering."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from collections.abc import Collection, Sequence
+from threading import Lock
+
+import numpy as np
+from chimerax.core.models import Model
+from chimerax.map import volume_from_grid_data
+from chimerax.map_data import ArrayGridData
+from lodstone import Layout, Planner, Stream, TileKey, Update, View
+from lodstone.sources import ArrayPyramidSource
+
+from .map_data.constants import UNITFACTOR
+from .map_data.ome_metadata import OMEZarrFormatError, parse_ome_zarr_metadata, spatial_transform_angstrom
+from .map_data.zarr_grid import _apply_omero_display, _supported_matrix_type
+
+DEFAULT_GPU_BUDGET = 512 * 1024**2
+
+
+def _update_volume_now(volume) -> None:
+    """Update one volume without leaving it in ChimeraX's global update sets."""
+
+    volume.update_drawings()
+    manager = getattr(volume.session, "_volume_update_manager", None)
+    if manager is not None:
+        manager._volumes_to_update.discard(volume)
+        manager._displayed_volumes_to_update.discard(volume)
+
+
+def _homogeneous_place(place) -> np.ndarray:
+    matrix = np.eye(4, dtype=np.float64)
+    matrix[:3, :] = place.matrix
+    return matrix
+
+
+def _level_transform(multiscales, dataset) -> np.ndarray:
+    """Build a full-axis Lodstone transform with spatial values in Angstrom."""
+
+    ndim = len(multiscales.axes)
+    transform = np.eye(ndim + 1, dtype=np.float64)
+    for axis_index, axis in enumerate(multiscales.axes):
+        factor = 1.0
+        if axis.type == "space":
+            try:
+                factor = UNITFACTOR[axis.unit or "angstrom"]
+            except KeyError as error:
+                raise OMEZarrFormatError(
+                    f"Unsupported spatial unit '{axis.unit}' on axis '{axis.name}'.",
+                ) from error
+        transform[axis_index, axis_index] = dataset.scale[axis_index] * factor
+        transform[axis_index, ndim] = dataset.translation[axis_index] * factor
+    return transform
+
+
+def source_from_group(group, metadata=None) -> ArrayPyramidSource:
+    """Adapt a normalized ChimeraX OME-Zarr group to a Lodstone source."""
+
+    metadata = metadata or parse_ome_zarr_metadata(group)
+    multiscales = metadata.multiscales
+    arrays = [group[dataset.path] for dataset in multiscales.datasets]
+    transforms = [_level_transform(multiscales, dataset) for dataset in multiscales.datasets]
+    return ArrayPyramidSource(
+        arrays,
+        axes=tuple(axis.name for axis in multiscales.axes),
+        transforms=transforms,
+        chunks=[tuple(int(value) for value in array.chunks) for array in arrays],
+    )
+
+
+class ChimeraXDispatcher:
+    """Drain Lodstone target calls on ChimeraX's graphics thread."""
+
+    def __init__(self, session) -> None:
+        self._callbacks = deque()
+        self._lock = Lock()
+        self._handler = session.triggers.add_handler("graphics update", self._graphics_update)
+
+    def __call__(self, callback) -> None:
+        with self._lock:
+            self._callbacks.append(callback)
+
+    def _graphics_update(self, *_args) -> None:
+        while True:
+            with self._lock:
+                if not self._callbacks:
+                    return
+                callback = self._callbacks.popleft()
+            callback()
+
+    def close(self) -> None:
+        if self._handler is not None:
+            self._handler.remove()
+            self._handler = None
+
+
+class ChimeraXVolumeTarget:
+    """Assemble Lodstone updates into mutable ChimeraX array-backed volumes."""
+
+    def __init__(
+        self,
+        owner,
+        source,
+        metadata,
+        displayed_axes,
+        *,
+        name: str,
+        channel_index: int,
+        time_index: int,
+        gpu_budget: int,
+    ) -> None:
+        self.owner = owner
+        self.session = owner.session
+        self.source = source
+        self.metadata = metadata
+        self.displayed_axes = tuple(displayed_axes)
+        self.name = name
+        self.channel_index = channel_index
+        self.time_index = time_index
+        self.gpu_budget = gpu_budget
+        self.buffers = {}
+        self.grids = {}
+        self.volumes = {}
+        self.level_keys = defaultdict(set)
+        self.current_level = None
+        self._value_ranges = {}
+
+        # Establish bounds before the first camera-driven plan. This lets the
+        # normal ChimeraX open/view logic position the camera around the data.
+        coarsest = len(source.pyramid.levels) - 1
+        self._ensure_level(coarsest)
+        self._show_level(coarsest)
+
+    def layout(self, view, pyramid) -> Layout:
+        return Layout(
+            kind="dense",
+            # Matching native chunks avoids repeatedly assembling overlapping
+            # remote slabs while ChimeraX progressively fills a dense texture.
+            block_shape=None,
+            mixed_lod=False,
+            memory_limit=self.gpu_budget,
+        )
+
+    def apply(self, updates: Sequence[Update]) -> None:
+        changed_levels = set()
+        for update in updates:
+            buffer, _grid, _volume = self._ensure_level(update.level)
+            slices = tuple(
+                slice(update.region.start[axis], update.region.stop[axis])
+                for axis in self.displayed_axes
+            )
+            values = _supported_matrix_type(update.data)
+            if len(self.displayed_axes) == 2:
+                slices = (slice(0, 1), *slices)
+                values = np.expand_dims(values, axis=0)
+            buffer[slices] = values
+            self.level_keys[update.level].add(update.key)
+            changed_levels.add(update.level)
+            self._observe_values(update.level, values)
+
+        for level in changed_levels:
+            self.grids[level].values_changed()
+            self._update_thresholds(level)
+            _update_volume_now(self.volumes[level])
+        if updates:
+            self._show_level(updates[-1].level)
+
+    def discard(self, keys: Collection[TileKey]) -> None:
+        discarded_by_level = defaultdict(set)
+        for key in keys:
+            discarded_by_level[key.level].add(key)
+        for level, discarded in discarded_by_level.items():
+            self.level_keys[level].difference_update(discarded)
+            if not self.level_keys[level] and level in self.volumes:
+                self.volumes[level].display = False
+
+    def redraw(self) -> None:
+        self.session.main_view.redraw_needed = True
+
+    def _ensure_level(self, level: int):
+        if level in self.buffers:
+            return self.buffers[level], self.grids[level], self.volumes[level]
+
+        level_info = self.source.pyramid.levels[level]
+        spatial_shape = tuple(level_info.shape[axis] for axis in self.displayed_axes)
+        dtype = np.float32 if level_info.dtype in (np.dtype(np.float16), np.dtype(np.uint64)) else level_info.dtype
+        buffer = np.zeros(spatial_shape, dtype=dtype)
+
+        dataset = self.metadata.multiscales.datasets[level]
+        step, origin = spatial_transform_angstrom(self.metadata.multiscales, dataset)
+        if len(spatial_shape) == 2:
+            buffer = np.expand_dims(buffer, axis=0)
+            step_xyz = (step[1], step[0], 1.0)
+            origin_xyz = (origin[1], origin[0], 0.0)
+        else:
+            step_xyz = tuple(reversed(step))
+            origin_xyz = tuple(reversed(origin))
+
+        grid = ArrayGridData(buffer, origin=origin_xyz, step=step_xyz, name=f"{self.name} L{level}")
+        volume = volume_from_grid_data(
+            grid,
+            self.session,
+            style="image",
+            open_model=False,
+            show_dialog=False,
+        )
+        volume.name = f"{self.name} L{level}"
+        _apply_omero_display(
+            volume,
+            self.metadata.omero,
+            self.channel_index,
+            self.time_index,
+            "channel" in [axis.type for axis in self.metadata.multiscales.axes],
+            "time" in [axis.type for axis in self.metadata.multiscales.axes],
+            self.name,
+        )
+        volume.display = False
+        self.owner.add([volume])
+
+        self.buffers[level] = buffer
+        self.grids[level] = grid
+        self.volumes[level] = volume
+        return buffer, grid, volume
+
+    def _show_level(self, level: int) -> None:
+        if self.current_level == level:
+            return
+        active = self._channel_active()
+        for existing_level, volume in self.volumes.items():
+            volume.display = active and existing_level == level
+            if volume.display:
+                _update_volume_now(volume)
+        self.current_level = level
+
+    def _channel_active(self) -> bool:
+        omero = self.metadata.omero
+        if omero and self.channel_index < len(omero.channels):
+            return omero.channels[self.channel_index].active
+        return self.time_index == 0
+
+    def _observe_values(self, level: int, values: np.ndarray) -> None:
+        if values.size == 0:
+            return
+        minimum = float(np.min(values))
+        maximum = float(np.max(values))
+        previous = self._value_ranges.get(level)
+        self._value_ranges[level] = (
+            minimum if previous is None else min(previous[0], minimum),
+            maximum if previous is None else max(previous[1], maximum),
+        )
+
+    def _update_thresholds(self, level: int) -> None:
+        volume = self.volumes[level]
+        omero = self.metadata.omero
+        if omero and self.channel_index < len(omero.channels):
+            window = omero.channels[self.channel_index].window
+            if window is not None and window.end > window.start:
+                volume.set_parameters(image_levels=[(window.start, 0.0), (window.end, 1.0)])
+                return
+        value_range = self._value_ranges.get(level)
+        if value_range is not None and value_range[1] > value_range[0]:
+            volume.set_parameters(image_levels=[(value_range[0], 0.0), (value_range[1], 1.0)])
+
+
+class LodstoneVolumeController:
+    """Translate the active ChimeraX camera into Lodstone view snapshots."""
+
+    def __init__(
+        self,
+        owner,
+        source,
+        target,
+        index,
+        displayed_axes,
+        dispatcher,
+    ) -> None:
+        self.owner = owner
+        self.session = owner.session
+        self.source = source
+        self.target = target
+        self.index = tuple(index)
+        self.displayed_axes = tuple(displayed_axes)
+        self.dispatcher = dispatcher
+        self._signature = None
+        self.stream = Stream(
+            source,
+            target,
+            planner=Planner(progressive=True),
+            dispatch=dispatcher,
+            workers=8,
+            cpu_cache=2 * 1024**3,
+            inflight=256 * 1024**2,
+            batch_size=8,
+        )
+        self._disconnect_status = self.stream.on_status_changed(self._status_changed)
+        self._handler = self.session.triggers.add_handler("graphics update", self._graphics_update)
+
+    def _graphics_update(self, *_args) -> None:
+        view, signature = self._view()
+        if self._signature is not None and np.allclose(signature, self._signature, rtol=1e-7, atol=1e-7):
+            return
+        self._signature = signature
+        plan = self.stream.update(view)
+        message = (
+            f"Lodstone {self.target.name}: loading {len(plan.wanted)} blocks "
+            f"toward level {plan.target_level}"
+        )
+        self.session.logger.info(message)
+
+    def _status_changed(self, status) -> None:
+        if status.state == "failed":
+            self.session.logger.warning(
+                f"Lodstone {self.target.name} failed: {status.error}",  # noqa: G004
+            )
+        elif status.state == "complete":
+            mib = status.bytes_read / 1024**2
+            message = (
+                f"Lodstone {self.target.name}: level ready "
+                f"({status.resident} blocks, {mib:.1f} MiB read)"
+            )
+            self.session.logger.info(message)
+
+    def _view(self):
+        main_view = self.session.main_view
+        camera = main_view.camera
+        window_size = tuple(int(value) for value in main_view.window_size)
+        near_far = main_view.near_far_distances(camera, 0)
+        projection = np.asarray(camera.projection_matrix(near_far, 0, window_size), dtype=np.float64)
+        scene_to_camera = np.asarray(camera.position.inverse().opengl_matrix(), dtype=np.float64).T
+        clip_from_scene = projection.T @ scene_to_camera
+
+        # Lodstone coordinates are ordered like displayed OME axes (normally
+        # Z,Y,X), whereas ChimeraX scene coordinates are X,Y,Z.
+        xyz_from_local = np.eye(4, dtype=np.float64)
+        xyz_from_local[:3, :3] = 0
+        for local_axis in range(len(self.displayed_axes)):
+            xyz_axis = len(self.displayed_axes) - 1 - local_axis
+            xyz_from_local[xyz_axis, local_axis] = 1
+
+        scene_from_xyz = _homogeneous_place(self.owner.scene_position)
+        world_to_clip = clip_from_scene @ scene_from_xyz @ xyz_from_local
+
+        eye_scene = np.asarray(camera.position.origin(), dtype=np.float64)
+        eye_xyz = np.linalg.solve(scene_from_xyz, np.append(eye_scene, 1.0))[:3]
+        eye_local = tuple(reversed(eye_xyz))
+        view = View(
+            displayed_axes=self.displayed_axes,
+            index=self.index,
+            viewport=window_size,
+            world_to_clip=world_to_clip,
+            eye=eye_local,
+        )
+        signature = np.concatenate([world_to_clip.ravel(), np.asarray(window_size)]).astype(np.float64)
+        return view, signature
+
+    def close(self) -> None:
+        if self._handler is not None:
+            self._handler.remove()
+            self._handler = None
+        self._disconnect_status()
+        self.stream.close()
+
+
+class LodstoneZarrModel(Model):
+    """Camera-driven progressive OME-Zarr model backed by Lodstone."""
+
+    def __init__(
+        self,
+        name: str,
+        session,
+        group,
+        *,
+        gpu_budget: int = DEFAULT_GPU_BUDGET,
+    ) -> None:
+        super().__init__(name, session)
+        self.group = group
+        self.ome_zarr_metadata = metadata = parse_ome_zarr_metadata(group)
+        self.source = source_from_group(group, metadata)
+        multiscales = metadata.multiscales
+        displayed_axes = multiscales.spatial_indices
+        axes_types = [axis.type for axis in multiscales.axes]
+        time_axis = axes_types.index("time") if "time" in axes_types else None
+        channel_axis = axes_types.index("channel") if "channel" in axes_types else None
+        finest_shape = self.source.pyramid.levels[0].shape
+        time_count = finest_shape[time_axis] if time_axis is not None else 1
+        channel_count = finest_shape[channel_axis] if channel_axis is not None else 1
+
+        self.dispatcher = ChimeraXDispatcher(session)
+        self.controllers = []
+        for time_index in range(time_count):
+            for channel_index in range(channel_count):
+                index = [None] * len(multiscales.axes)
+                if time_axis is not None:
+                    index[time_axis] = time_index
+                if channel_axis is not None:
+                    index[channel_axis] = channel_index
+                target = ChimeraXVolumeTarget(
+                    self,
+                    self.source,
+                    metadata,
+                    displayed_axes,
+                    name=name,
+                    channel_index=channel_index,
+                    time_index=time_index,
+                    gpu_budget=gpu_budget,
+                )
+                self.controllers.append(
+                    LodstoneVolumeController(
+                        self,
+                        self.source,
+                        target,
+                        index,
+                        displayed_axes,
+                        self.dispatcher,
+                    ),
+                )
+
+    @property
+    def scales(self):
+        return [dataset.path for dataset in self.ome_zarr_metadata.multiscales.datasets]
+
+    def delete(self) -> None:
+        for controller in self.controllers:
+            controller.close()
+        self.dispatcher.close()
+        super().delete()

--- a/src/open.py
+++ b/src/open.py
@@ -451,10 +451,24 @@ def _open(
     labels: bool = False,
     read_ahead: Optional[int] = None,
     filesystem: Optional[AbstractFileSystem] = None,
+    streaming: bool = False,
 ) -> Tuple[List[Model], str]:
     group = _open_group(session, root)
     kind = ome_zarr_group_kind(group)
-    if kind == "image":
+    if streaming:
+        if kind != "image":
+            raise OMEZarrFormatError("Lodstone streaming currently supports direct OME-Zarr image groups only.")
+        if scales is not None or labels:
+            raise OMEZarrFormatError("Lodstone streaming selects scales automatically and does not yet open labels.")
+        try:
+            from .lodstone_adapter import LodstoneZarrModel
+        except ImportError as error:
+            raise OMEZarrFormatError(
+                "Lodstone streaming is not installed; install the bundle's streaming extra.",
+            ) from error
+
+        model = LodstoneZarrModel(name, session, group)
+    elif kind == "image":
         model = _open_image_group(session, group, name, scales, initial_step, labels, read_ahead)
     elif kind == "bioformats2raw":
         model = _open_bioformats2raw_collection(
@@ -483,6 +497,7 @@ def open_ome_zarr(
     scales: List[str] = None,
     labels: bool = False,
     read_ahead: Optional[int] = None,
+    streaming: bool = False,
 ) -> Tuple[List[Model], str]:
     """Open local or remote OME-Zarr images, optionally with associated labels."""
 
@@ -501,6 +516,7 @@ def open_ome_zarr(
             labels=labels,
             read_ahead=read_ahead,
             filesystem=filesystem,
+            streaming=streaming,
         )
         retm.extend(models)
         rets.append(message)
@@ -516,6 +532,7 @@ def open_ome_zarr_from_fs(
     log: bool = True,
     labels: bool = False,
     read_ahead: Optional[int] = None,
+    streaming: bool = False,
 ) -> Tuple[List[Model], str]:
     root = _store_from_filesystem(fs, path)
     if log:
@@ -524,7 +541,11 @@ def open_ome_zarr_from_fs(
         proto = fs.protocol[0] if isinstance(fs.protocol, tuple) else fs.protocol
         label_option = " labels true" if labels else ""
         read_ahead_option = "" if read_ahead is None else f" readAhead {read_ahead}"
-        log_equivalent_command(session, f"open ngff:{proto}://{path}{label_option}{read_ahead_option}")
+        streaming_option = " streaming true" if streaming else ""
+        log_equivalent_command(
+            session,
+            f"open ngff:{proto}://{path}{label_option}{read_ahead_option}{streaming_option}",
+        )
     return _open(
         session,
         root,
@@ -535,6 +556,7 @@ def open_ome_zarr_from_fs(
         labels=labels,
         read_ahead=read_ahead,
         filesystem=fs,
+        streaming=streaming,
     )
 
 
@@ -546,6 +568,7 @@ def open_ome_zarr_from_store(
     initial_step: Tuple[int, int, int] = (4, 4, 4),
     labels: bool = False,
     read_ahead: Optional[int] = None,
+    streaming: bool = False,
 ) -> Tuple[List[Model], str]:
     return _open(
         session,
@@ -556,4 +579,5 @@ def open_ome_zarr_from_store(
         initial_step=initial_step,
         labels=labels,
         read_ahead=read_ahead,
+        streaming=streaming,
     )

--- a/src/open.py
+++ b/src/open.py
@@ -452,9 +452,12 @@ def _open(
     read_ahead: Optional[int] = None,
     filesystem: Optional[AbstractFileSystem] = None,
     streaming: bool = False,
+    time: Optional[int] = None,
 ) -> Tuple[List[Model], str]:
     group = _open_group(session, root)
     kind = ome_zarr_group_kind(group)
+    if time is not None and not streaming:
+        raise OMEZarrFormatError("the time option currently requires 'streaming true'.")
     if streaming:
         if kind != "image":
             raise OMEZarrFormatError("Lodstone streaming currently supports direct OME-Zarr image groups only.")
@@ -467,7 +470,7 @@ def _open(
                 "Lodstone streaming is not installed; install the bundle's streaming extra.",
             ) from error
 
-        model = LodstoneZarrModel(name, session, group)
+        model = LodstoneZarrModel(name, session, group, time_index=time)
     elif kind == "image":
         model = _open_image_group(session, group, name, scales, initial_step, labels, read_ahead)
     elif kind == "bioformats2raw":
@@ -498,6 +501,7 @@ def open_ome_zarr(
     labels: bool = False,
     read_ahead: Optional[int] = None,
     streaming: bool = False,
+    time: Optional[int] = None,
 ) -> Tuple[List[Model], str]:
     """Open local or remote OME-Zarr images, optionally with associated labels."""
 
@@ -517,6 +521,7 @@ def open_ome_zarr(
             read_ahead=read_ahead,
             filesystem=filesystem,
             streaming=streaming,
+            time=time,
         )
         retm.extend(models)
         rets.append(message)
@@ -533,6 +538,7 @@ def open_ome_zarr_from_fs(
     labels: bool = False,
     read_ahead: Optional[int] = None,
     streaming: bool = False,
+    time: Optional[int] = None,
 ) -> Tuple[List[Model], str]:
     root = _store_from_filesystem(fs, path)
     if log:
@@ -542,9 +548,10 @@ def open_ome_zarr_from_fs(
         label_option = " labels true" if labels else ""
         read_ahead_option = "" if read_ahead is None else f" readAhead {read_ahead}"
         streaming_option = " streaming true" if streaming else ""
+        time_option = "" if time is None else f" time {time}"
         log_equivalent_command(
             session,
-            f"open ngff:{proto}://{path}{label_option}{read_ahead_option}{streaming_option}",
+            f"open ngff:{proto}://{path}{label_option}{read_ahead_option}{streaming_option}{time_option}",
         )
     return _open(
         session,
@@ -557,6 +564,7 @@ def open_ome_zarr_from_fs(
         read_ahead=read_ahead,
         filesystem=fs,
         streaming=streaming,
+        time=time,
     )
 
 
@@ -569,6 +577,7 @@ def open_ome_zarr_from_store(
     labels: bool = False,
     read_ahead: Optional[int] = None,
     streaming: bool = False,
+    time: Optional[int] = None,
 ) -> Tuple[List[Model], str]:
     return _open(
         session,
@@ -580,4 +589,5 @@ def open_ome_zarr_from_store(
         labels=labels,
         read_ahead=read_ahead,
         streaming=streaming,
+        time=time,
     )

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -8,6 +8,7 @@ import pytest
 import zarr
 
 from src.info import NGFFFetcherInfo, OMEZarrOpenerInfo
+from src.lodstone_adapter import source_from_group
 from src.map_data.ome_metadata import (
     OMEZarrFormatError,
     bioformats2raw_series_paths,
@@ -238,6 +239,30 @@ def test_dataset_and_group_transforms_are_composed_and_converted(zarr_format):
     # Spatial units are nanometers, so values are multiplied by 10 Angstrom/nm.
     assert step == pytest.approx((200.0, 300.0))
     assert origin == pytest.approx((610.0, 720.0))
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3])
+def test_lodstone_source_preserves_axes_chunks_and_angstrom_transforms(zarr_format):
+    group, data = _make_image(
+        zarr_format,
+        ["channel", "space", "space", "space"],
+        (2, 4, 6, 8),
+        transforms=[
+            {"type": "scale", "scale": [1, 2, 3, 4]},
+            {"type": "translation", "translation": [0, 5, 6, 7]},
+        ],
+    )
+
+    source = source_from_group(group)
+    level = source.pyramid.levels[0]
+
+    assert source.pyramid.axes == ("c", "z", "y", "x")
+    assert level.shape == data.shape
+    assert level.chunks == (2, 4, 4, 4)
+    # _make_image uses nanometers for spatial axes; Lodstone/ChimeraX share
+    # Angstrom world coordinates at this boundary.
+    np.testing.assert_allclose(np.diag(level.voxel_to_world), (1, 20, 30, 40, 1))
+    np.testing.assert_allclose(level.voxel_to_world[:-1, -1], (0, 50, 60, 70))
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -372,6 +372,12 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
     target.apply(changes)
     assert target.current_window is None
     assert lease.available_keys == frozenset({key})
+    stale_publications = target.stage_phase(None, plan, 0)
+    target.invalidate_request(2)
+    target.phase_complete(None, plan, 0, stale_publications)
+    assert window not in target.resources
+
+    target.register_plan(plan, 3, "test")
     publications = target.stage_phase(None, plan, 0)
     target.phase_complete(None, plan, 0, publications)
     _live_buffer, published_grid, published_volume = target.resources[window]

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -6,9 +6,10 @@ import fsspec
 import numpy as np
 import pytest
 import zarr
+from lodstone import Plan, Region, Tile, TileKey, Update
 
 from src.info import NGFFFetcherInfo, OMEZarrOpenerInfo
-from src.lodstone_adapter import source_from_group
+from src.lodstone_adapter import ChimeraXVolumeTarget, source_from_group
 from src.map_data.ome_metadata import (
     OMEZarrFormatError,
     bioformats2raw_series_paths,
@@ -263,6 +264,109 @@ def test_lodstone_source_preserves_axes_chunks_and_angstrom_transforms(zarr_form
     # Angstrom world coordinates at this boundary.
     np.testing.assert_allclose(np.diag(level.voxel_to_world), (1, 20, 30, 40, 1))
     np.testing.assert_allclose(level.voxel_to_world[:-1, -1], (0, 50, 60, 70))
+
+
+def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
+    group, _data = _make_image(
+        3,
+        ["time", "space", "space", "space"],
+        (1, 20, 30, 40),
+    )
+    metadata = parse_ome_zarr_metadata(group)
+    source = source_from_group(group, metadata)
+
+    class Grid:
+        def __init__(self, matrix, *, origin, step, name):
+            self.matrix = matrix
+            self.origin = origin
+            self.step = step
+            self.name = name
+            self.changed = 0
+
+        def values_changed(self):
+            self.changed += 1
+
+    class Volume:
+        def __init__(self, grid, session):
+            self.grid = grid
+            self.session = session
+            self.display = False
+            self.deleted = False
+            self.parameters = []
+
+        def update_drawings(self):
+            return None
+
+        def set_parameters(self, **kwargs):
+            self.parameters.append(kwargs)
+
+        def delete(self):
+            self.deleted = True
+
+    monkeypatch.setattr("src.lodstone_adapter.ArrayGridData", Grid)
+    monkeypatch.setattr(
+        "src.lodstone_adapter.volume_from_grid_data",
+        lambda grid, session, **_kwargs: Volume(grid, session),
+    )
+
+    session = type(
+        "Session",
+        (),
+        {"main_view": type("MainView", (), {"redraw_needed": False})()},
+    )()
+
+    class Owner:
+        def __init__(self):
+            self.session = session
+            self.children = []
+
+        def add(self, models):
+            self.children.extend(models)
+
+    owner = Owner()
+    target = ChimeraXVolumeTarget(
+        owner,
+        source,
+        metadata,
+        (1, 2, 3),
+        name="bounded",
+        channel_index=0,
+        time_index=0,
+        gpu_budget=1024**2,
+    )
+    bounds_grid = target._bounds_resource[1]
+    assert bounds_grid.matrix.shape == (2, 2, 2)
+    assert bounds_grid.step == pytest.approx((390, 290, 190))
+    key = TileKey(0, (0, 0, 0), (0, -1, -1, -1))
+    region = Region((0, 4, 5, 6), (1, 8, 10, 12))
+    tile = Tile(key, region, 0.0)
+    plan = Plan((tile,), frozenset({key}), 0, (tile,))
+
+    target.prepare(None, plan)
+    window = target.resident.windows[0]
+    _buffer, grid, _volume = target.resources[window]
+
+    assert window.data.shape == (1, 4, 5, 6)
+    assert grid.matrix.shape == (4, 5, 6)
+    assert grid.origin == pytest.approx((60, 50, 40))
+    assert window.nbytes < np.prod(source.pyramid.levels[0].shape) * 2
+
+    target.apply(
+        [
+            Update(
+                key,
+                region,
+                np.ones(region.shape, dtype=np.uint16),
+                source.pyramid.levels[0].voxel_to_world,
+            ),
+        ],
+    )
+    target.complete(None, plan)
+
+    assert np.all(grid.matrix == 1)
+    assert grid.changed == 1
+    assert target.resident.active == {0: window}
+    assert target._bounds_resource is None
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -458,6 +458,39 @@ def test_chimerax_dispatcher_runs_one_callback_per_graphics_cycle():
     assert calls == [1, 2]
 
 
+def test_lodstone_volume_deletion_is_idempotent():
+    class Manager:
+        def __init__(self):
+            self._volumes_to_update = set()
+            self._displayed_volumes_to_update = set()
+
+    class Volume:
+        def __init__(self):
+            self.deleted = False
+            self.display = True
+            self.session = type("Session", (), {})()
+            self.session._volume_update_manager = Manager()
+            self.session._volume_update_manager._volumes_to_update.add(self)
+            self.session._volume_update_manager._displayed_volumes_to_update.add(self)
+            self.delete_calls = 0
+
+        def delete(self):
+            if self.deleted:
+                raise RuntimeError("deleted twice")
+            self.deleted = True
+            self.delete_calls += 1
+
+    volume = Volume()
+    ChimeraXVolumeTarget._delete_volume(volume)
+    ChimeraXVolumeTarget._delete_volume(volume)
+
+    assert volume.deleted
+    assert not volume.display
+    assert volume.delete_calls == 1
+    assert not volume.session._volume_update_manager._volumes_to_update
+    assert not volume.session._volume_update_manager._displayed_volumes_to_update
+
+
 def test_lodstone_multichannel_back_buffers_switch_before_fronts_retire():
     events = []
 

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -527,6 +527,7 @@ def test_lodstone_target_keeps_coarse_context_and_user_contrast(monkeypatch):
         gpu_budget=1024**2,
     )
     assert target.layout(None, source.pyramid).mixed_lod
+    assert target.layout(None, source.pyramid).focus_depth_weight == 0.5
 
     selection = (0, -1, -1, -1)
     coarse_key = TileKey(1, (0, 0, 0), selection)

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -9,7 +9,12 @@ import zarr
 from lodstone import Plan, Region, Tile, TileKey, Update
 
 from src.info import NGFFFetcherInfo, OMEZarrOpenerInfo
-from src.lodstone_adapter import ChimeraXVolumeTarget, LodstoneZarrModel, source_from_group
+from src.lodstone_adapter import (
+    ChimeraXVolumeTarget,
+    LodstoneVolumeController,
+    LodstoneZarrModel,
+    source_from_group,
+)
 from src.map_data.ome_metadata import (
     OMEZarrFormatError,
     bioformats2raw_series_paths,
@@ -393,6 +398,55 @@ def test_lodstone_streaming_rejects_multiple_timepoints_before_starting_streams(
 
     with pytest.raises(OMEZarrFormatError, match="switching timepoints"):
         LodstoneZarrModel("time series", session, group)
+
+
+def test_lodstone_controller_skips_coverage_equivalent_plan_submissions():
+    key0 = TileKey(0, (0, 0, 0), (-1, -1, -1))
+    key1 = TileKey(0, (0, 0, 1), (-1, -1, -1))
+    tile0 = Tile(key0, Region((0, 0, 0), (4, 4, 4)), 1.0)
+    tile1 = Tile(key1, Region((0, 0, 4), (4, 4, 8)), 2.0)
+    initial = Plan((tile0, tile1), frozenset({key0, key1}), 0, (tile0, tile1))
+    reprioritized0 = Tile(key0, tile0.region, -2.0, 7)
+    reprioritized1 = Tile(key1, tile1.region, -1.0, 7)
+    equivalent = Plan(
+        (reprioritized1, reprioritized0),
+        initial.retain,
+        0,
+        (reprioritized1, reprioritized0),
+    )
+    changed_tile1 = Tile(key1, Region((0, 0, 4), (4, 4, 7)), 2.0)
+    changed = Plan(
+        (tile0, changed_tile1),
+        initial.retain,
+        0,
+        (tile0, changed_tile1),
+    )
+
+    class StreamStub:
+        def __init__(self):
+            self.plans = iter((initial, equivalent, changed))
+            self.submissions = []
+
+        def plan(self, _view, **_kwargs):
+            return next(self.plans)
+
+        def submit(self, view, plan):
+            self.submissions.append((view, plan))
+
+    logger = type("Logger", (), {"status": lambda *_args, **_kwargs: None})()
+    controller = LodstoneVolumeController.__new__(LodstoneVolumeController)
+    controller.stream = StreamStub()
+    controller.session = type("Session", (), {"logger": logger})()
+    controller.target = type("Target", (), {"name": "test"})()
+    controller._target_level = None
+    controller._active_coverage = None
+    view = object()
+
+    controller._submit_view(view)
+    controller._submit_view(view)
+    controller._submit_view(view)
+
+    assert [plan for _view, plan in controller.stream.submissions] == [initial, changed]
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -6,7 +6,7 @@ import fsspec
 import numpy as np
 import pytest
 import zarr
-from lodstone import Plan, Region, ResidentWindow, Tile, TileKey, Update
+from lodstone import Layout, Plan, Region, ResidentWindow, Runtime, Tile, TileKey, Update
 
 from src.info import NGFFFetcherInfo, OMEZarrOpenerInfo
 from src.lodstone_adapter import (
@@ -573,6 +573,63 @@ def test_lodstone_controller_skips_coverage_equivalent_plan_submissions():
     controller._submit_planned(view, changed, 3, "test")
 
     assert [plan for _view, plan in controller.stream.submissions] == [initial, changed]
+
+
+def test_lodstone_controller_uses_model_shared_runtime():
+    group, _data = _make_image(
+        3,
+        ["channel", "space", "space", "space"],
+        (1, 4, 4, 4),
+    )
+    source = source_from_group(group)
+
+    class Handler:
+        def remove(self):
+            return None
+
+    class Triggers:
+        def add_handler(self, _name, _callback):
+            return Handler()
+
+    runtime = Runtime()
+    session = type("Session", (), {"triggers": Triggers()})()
+    owner = type(
+        "Owner",
+        (),
+        {"session": session, "runtime": runtime, "deleted": False},
+    )()
+
+    class Target:
+        gpu_budget = 1024**2
+        name = "shared-runtime"
+
+        def layout(self, _view, _pyramid):
+            return Layout(kind="dense", squeeze_hidden=False)
+
+        def apply(self, _updates):
+            return None
+
+        def discard(self, _keys):
+            return None
+
+        def redraw(self):
+            return None
+
+    controller = LodstoneVolumeController(
+        owner,
+        source,
+        Target(),
+        (0, None, None, None),
+        (1, 2, 3),
+        lambda callback: callback(),
+    )
+    try:
+        assert controller.stream.runtime is runtime
+        controller.close()
+        assert not runtime.closed
+    finally:
+        controller.close()
+        runtime.close()
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -362,6 +362,9 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
             ),
         ],
     )
+    assert target.current_window is None
+    target.phase_complete(None, plan, 0)
+    assert target.current_window is window
     target.complete(None, plan)
 
     assert np.all(grid.matrix == 1)

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -9,7 +9,7 @@ import zarr
 from lodstone import Plan, Region, Tile, TileKey, Update
 
 from src.info import NGFFFetcherInfo, OMEZarrOpenerInfo
-from src.lodstone_adapter import ChimeraXVolumeTarget, LodstoneZarrModel, _patch_volume_texture, source_from_group
+from src.lodstone_adapter import ChimeraXVolumeTarget, LodstoneZarrModel, source_from_group
 from src.map_data.ome_metadata import (
     OMEZarrFormatError,
     bioformats2raw_series_paths,
@@ -363,75 +363,22 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
         ],
     )
     assert target.current_window is None
+    assert grid.changed == 0
+    assert volume.drawing_updates == 0
     target.phase_complete(None, plan, 0)
+    _live_buffer, published_grid, published_volume = target.resources[window]
     assert target.current_window is window
+    assert volume.deleted
+    assert published_volume.drawing_updates == 1
+    assert target._bounds_resource is None
     target.complete(None, plan)
 
     assert np.all(grid.matrix == 1)
-    assert grid.changed == 1
-    assert volume.drawing_updates == 0
+    assert grid.changed == 0
+    assert np.all(published_grid.matrix == 1)
+    assert not np.shares_memory(grid.matrix, published_grid.matrix)
     assert target.resident.active == {0: window}
     assert target._bounds_resource is None
-
-
-def test_lodstone_target_patches_initialized_scalar_texture(monkeypatch):
-    buffer = np.arange(4 * 5 * 6, dtype=np.uint16).reshape((4, 5, 6))
-    window = type("Window", (), {"region": Region((0, 10, 20, 30), (1, 14, 25, 36))})()
-    update_region = Region((0, 11, 22, 33), (1, 13, 25, 36))
-    update = type("Update", (), {"region": update_region})()
-    texture = type(
-        "Texture",
-        (),
-        {
-            "id": 7,
-            "dimension": 3,
-            "data": None,
-            "_array_shape": buffer.shape,
-            "_numpy_dtype": buffer.dtype,
-        },
-    )()
-    image = type(
-        "Image",
-        (),
-        {
-            "deleted": False,
-            "_rendering_options": type("Options", (), {"colormap_on_gpu": True})(),
-            "_blend_image": None,
-            "_p_mode": "3d",
-            "_use_3d_texture": True,
-            "_planes_3d": type("Drawing", (), {"texture": texture})(),
-        },
-    )()
-
-    class Render:
-        current = 0
-
-        def make_current(self):
-            self.current += 1
-
-    render = Render()
-    volume = type(
-        "Volume",
-        (),
-        {
-            "_image": image,
-            "session": type("Session", (), {"main_view": type("MainView", (), {"render": render})()})(),
-        },
-    )()
-    uploads = []
-    monkeypatch.setattr(
-        "src.lodstone_adapter._upload_texture_3d",
-        lambda actual_texture, data, offset: uploads.append((actual_texture, data.copy(), offset)),
-    )
-
-    patched = _patch_volume_texture(volume, buffer, window, (update,), (1, 2, 3))
-
-    assert patched
-    assert render.current == 1
-    assert len(uploads) == 1
-    assert uploads[0][0] is texture
-    assert uploads[0][2] == (1, 2, 3)
-    np.testing.assert_array_equal(uploads[0][1], buffer[1:3, 2:5, 3:6])
 
 
 def test_lodstone_streaming_rejects_multiple_timepoints_before_starting_streams():

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -9,7 +9,7 @@ import zarr
 from lodstone import Plan, Region, Tile, TileKey, Update
 
 from src.info import NGFFFetcherInfo, OMEZarrOpenerInfo
-from src.lodstone_adapter import ChimeraXVolumeTarget, _patch_volume_texture, source_from_group
+from src.lodstone_adapter import ChimeraXVolumeTarget, LodstoneZarrModel, _patch_volume_texture, source_from_group
 from src.map_data.ome_metadata import (
     OMEZarrFormatError,
     bioformats2raw_series_paths,
@@ -427,6 +427,20 @@ def test_lodstone_target_patches_initialized_scalar_texture(monkeypatch):
     assert uploads[0][0] is texture
     assert uploads[0][2] == (1, 2, 3)
     np.testing.assert_array_equal(uploads[0][1], buffer[1:3, 2:5, 3:6])
+
+
+def test_lodstone_streaming_rejects_multiple_timepoints_before_starting_streams():
+    from chimerax.core.session import Session
+
+    group, _data = _make_image(
+        3,
+        ["time", "space", "space", "space"],
+        (2, 4, 6, 8),
+    )
+    session = Session("OME-Zarr Lodstone time-series test", offscreen_rendering=True)
+
+    with pytest.raises(OMEZarrFormatError, match="switching timepoints"):
+        LodstoneZarrModel("time series", session, group)
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -293,9 +293,10 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
             self.display = False
             self.deleted = False
             self.parameters = []
+            self.drawing_updates = 0
 
         def update_drawings(self):
-            return None
+            self.drawing_updates += 1
 
         def set_parameters(self, **kwargs):
             self.parameters.append(kwargs)
@@ -344,7 +345,7 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
 
     target.prepare(None, plan)
     window = target.resident.windows[0]
-    _buffer, grid, _volume = target.resources[window]
+    _buffer, grid, volume = target.resources[window]
 
     assert window.data.shape == (1, 4, 5, 6)
     assert grid.matrix.shape == (4, 5, 6)
@@ -365,6 +366,7 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
 
     assert np.all(grid.matrix == 1)
     assert grid.changed == 1
+    assert volume.drawing_updates == 0
     assert target.resident.active == {0: window}
     assert target._bounds_resource is None
 

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -6,7 +6,7 @@ import fsspec
 import numpy as np
 import pytest
 import zarr
-from lodstone import Layout, Plan, Region, ResidentWindow, Runtime, Tile, TileKey, Update
+from lodstone import Layout, Plan, Planner, Region, ResidentWindow, Runtime, Tile, TileKey, Update, View
 
 from src.info import NGFFFetcherInfo, OMEZarrOpenerInfo
 from src.lodstone_adapter import (
@@ -119,6 +119,31 @@ def _make_image(
             ome["omero"] = omero
         group.attrs["ome"] = ome
     return group, data
+
+
+def _add_coarse_level(group, zarr_format, data, scale):
+    axes = group.attrs["multiscales"][0]["axes"] if zarr_format == 2 else group.attrs["ome"]["multiscales"][0]["axes"]
+    names = tuple(axis["name"] for axis in axes)
+    _create_array(
+        group,
+        zarr_format,
+        "1",
+        data,
+        tuple(max(1, min(4, size)) for size in data.shape),
+        dimension_names=names,
+    )
+    if zarr_format == 2:
+        metadata = deepcopy(group.attrs["multiscales"])
+        metadata[0]["datasets"].append(
+            {"path": "1", "coordinateTransformations": [{"type": "scale", "scale": scale}]},
+        )
+        group.attrs["multiscales"] = metadata
+    else:
+        metadata = deepcopy(group.attrs["ome"])
+        metadata["multiscales"][0]["datasets"].append(
+            {"path": "1", "coordinateTransformations": [{"type": "scale", "scale": scale}]},
+        )
+        group.attrs["ome"] = metadata
 
 
 def _make_bioformats2raw_collection(zarr_format, series_paths, *, explicit_series):
@@ -416,6 +441,149 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
     assert all(record.bytes_processed == 0 for record in target.timeline if record.operation == "target.apply")
 
 
+def test_lodstone_target_keeps_coarse_context_and_user_contrast(monkeypatch):
+    group, _fine = _make_image(
+        3,
+        ["time", "space", "space", "space"],
+        (1, 8, 8, 8),
+    )
+    coarse = np.arange(1, 65, dtype=np.uint16).reshape(1, 4, 4, 4)
+    _add_coarse_level(group, 3, coarse, [1, 2, 2, 2])
+    metadata = parse_ome_zarr_metadata(group)
+    source = source_from_group(group, metadata)
+
+    class Grid:
+        def __init__(self, array, *, origin, step, name):
+            self.array = array
+            self.origin = origin
+            self.step = step
+            self.name = name
+            self.changed = 0
+
+        def values_changed(self):
+            self.changed += 1
+
+    class Volume:
+        def __init__(self, grid, session):
+            self.grid = grid
+            self.session = session
+            self.display = False
+            self.deleted = False
+            self.image_levels = [(0.0, 0.0), (1.0, 1.0)]
+            self.image_colors = [(1.0, 1.0, 1.0, 1.0)] * 2
+            self.image_brightness_factor = 1.0
+            self.transparency_depth = 0.5
+            self.default_rgba = (1.0, 1.0, 1.0, 1.0)
+            self.change_callbacks = []
+
+        def add_volume_change_callback(self, callback):
+            self.change_callbacks.append(callback)
+
+        def update_drawings(self):
+            return None
+
+        def set_parameters(self, **kwargs):
+            for name, value in kwargs.items():
+                setattr(self, name, list(value) if name in {"image_levels", "image_colors"} else value)
+            changes = []
+            if "image_levels" in kwargs:
+                changes.append("thresholds changed")
+            if set(kwargs) - {"image_levels"}:
+                changes.append("colors changed")
+            for callback in tuple(self.change_callbacks):
+                for change in changes:
+                    callback(self, change)
+
+        def delete(self):
+            self.deleted = True
+
+    monkeypatch.setattr("src.lodstone_adapter.ArrayGridData", Grid)
+    monkeypatch.setattr(
+        "src.lodstone_adapter.volume_from_grid_data",
+        lambda grid, session, **_kwargs: Volume(grid, session),
+    )
+    session = type(
+        "Session",
+        (),
+        {"main_view": type("MainView", (), {"redraw_needed": False})()},
+    )()
+
+    class Owner:
+        def __init__(self):
+            self.session = session
+            self.children = []
+
+        def add(self, models):
+            self.children.extend(models)
+
+    target = ChimeraXVolumeTarget(
+        Owner(),
+        source,
+        metadata,
+        (1, 2, 3),
+        name="clipmap",
+        channel_index=0,
+        time_index=0,
+        gpu_budget=1024**2,
+    )
+    assert target.layout(None, source.pyramid).mixed_lod
+
+    selection = (0, -1, -1, -1)
+    coarse_key = TileKey(1, (0, 0, 0), selection)
+    fine_key = TileKey(0, (0, 0, 0), selection)
+    coarse_region = Region((0, 0, 0, 0), (1, 4, 4, 4))
+    fine_region = Region((0, 2, 2, 2), (1, 6, 6, 6))
+    coarse_tile = Tile(coarse_key, coarse_region, 0.0, 0)
+    fine_tile = Tile(fine_key, fine_region, 0.0, 1)
+    plan = Plan(
+        (coarse_tile, fine_tile),
+        frozenset({coarse_key, fine_key}),
+        0,
+        (coarse_tile, fine_tile),
+    )
+    target.register_plan(plan, 1, "test")
+    prepared = target.stage_prepare(None, plan)
+    target.prepare(None, plan, prepared)
+    sparse_focus = np.zeros(fine_region.shape, dtype=np.uint16)
+    sparse_focus[(0, 1, 1, 1)] = 100
+    target.stage(
+        [
+            Update(
+                coarse_key,
+                coarse_region,
+                coarse,
+                source.pyramid.levels[1].voxel_to_world,
+            ),
+            Update(
+                fine_key,
+                fine_region,
+                sparse_focus,
+                source.pyramid.levels[0].voxel_to_world,
+            ),
+        ],
+    )
+
+    target.phase_complete(None, plan, 0, target.stage_phase(None, plan, 0))
+    context_window, (_base, context_grid, context_volume) = target._front_resources[1]
+    assert context_volume.display
+    assert context_volume.image_levels == [(1.0, 0.0), (64.0, 1.0)]
+
+    target.phase_complete(None, plan, 1, target.stage_phase(None, plan, 1))
+    _focus_window, (_focus, _focus_grid, focus_volume) = target._front_resources[0]
+    assert context_window.level == 1
+    assert context_volume.display and focus_volume.display
+    assert focus_volume.image_levels == context_volume.image_levels
+    masked_context = np.count_nonzero(context_grid.array == 0)
+    assert 0 < masked_context < context_grid.array.size
+
+    focus_volume.set_parameters(image_levels=[(20.0, 0.0), (40.0, 1.0)])
+    assert context_volume.image_levels == [(20.0, 0.0), (40.0, 1.0)]
+
+    target.complete(None, plan)
+    assert set(target.resident.active) == {0, 1}
+    assert set(target._front_resources) == {0, 1}
+
+
 def test_lodstone_snapshot_is_immutable_and_upload_bounded():
     target = ChimeraXVolumeTarget.__new__(ChimeraXVolumeTarget)
     target.displayed_axes = (1, 2, 3)
@@ -536,6 +704,47 @@ def test_lodstone_multichannel_back_buffers_switch_before_fronts_retire():
     assert events[2:4] == [("delete", "front-0"), ("delete", "front-1")]
 
 
+def test_lodstone_context_phase_keeps_previous_focus_until_detail_is_ready():
+    events = []
+
+    class Target:
+        _planned_target_level = 0
+        _context_level = 2
+
+        def __init__(self):
+            self._back_resources = {2: (object(), object())}
+
+        def _activate_back(self, level):
+            self._back_resources.pop(level)
+            events.append(("activate", level))
+            return None
+
+        def _hide_other_focus_levels(self, level):
+            events.append(("hide", level))
+
+        def _retain_clipmap_levels(self, levels):
+            events.append(("retain", levels))
+
+        def _flush_deferred_retired(self):
+            events.append(("flush",))
+
+    target = Target()
+    model = type("StreamingModel", (), {})()
+    model.controllers = [type("Controller", (), {"target": target})()]
+    model.session = type(
+        "Session",
+        (),
+        {"main_view": type("MainView", (), {"redraw_needed": False})()},
+    )()
+    queued = []
+    model.dispatcher = queued.append
+
+    LodstoneZarrModel.present_lodstone_level(model, 2)
+    queued.pop()()
+
+    assert events == [("activate", 2)]
+
+
 def test_lodstone_streaming_requires_one_selected_timepoint():
     from chimerax.core.session import Session
 
@@ -618,6 +827,65 @@ def test_lodstone_controller_skips_coverage_equivalent_plan_submissions():
     controller._submit_planned(view, changed, 3, "test")
 
     assert [plan for _view, plan in controller.stream.submissions] == [initial, changed]
+
+
+def test_lodstone_controller_prefixes_full_coarse_context():
+    group, _fine = _make_image(
+        3,
+        ["time", "space", "space", "space"],
+        (1, 8, 8, 8),
+    )
+    _add_coarse_level(
+        group,
+        3,
+        np.ones((1, 4, 4, 4), dtype=np.uint16),
+        [1, 2, 2, 2],
+    )
+    source = source_from_group(group)
+    fine_key = TileKey(0, (0, 0, 0), (0, -1, -1, -1))
+    fine_tile = Tile(
+        fine_key,
+        Region((0, 2, 2, 2), (1, 6, 6, 6)),
+        0.0,
+        1,
+    )
+    primary = Plan((fine_tile,), frozenset({fine_key}), 0, (fine_tile,))
+
+    class StreamStub:
+        available = frozenset()
+        planner = Planner()
+
+        def plan(self, _view, **_kwargs):
+            return primary
+
+    target = type(
+        "Target",
+        (),
+        {
+            "context_budget": 1024**2,
+            "layout": lambda _self, _view, _pyramid: Layout(max_axis_extent=512),
+        },
+    )()
+    controller = LodstoneVolumeController.__new__(LodstoneVolumeController)
+    controller.stream = StreamStub()
+    controller.source = source
+    controller.target = target
+    controller.displayed_axes = (1, 2, 3)
+    view = View(
+        displayed_axes=(1, 2, 3),
+        index=(0, None, None, None),
+        viewport=(512, 512),
+        world_to_clip=np.eye(4),
+    )
+
+    plan = controller._plan_view(view, previous_target_level=None)
+    context_tiles = [tile for tile in plan.desired if tile.level == 1]
+
+    assert plan.target_level == 0
+    assert context_tiles
+    assert min(tile.region.start for tile in context_tiles) == (0, 0, 0, 0)
+    assert max(tile.region.stop for tile in context_tiles) == (1, 4, 4, 4)
+    assert {key.level for key in plan.retain} == {0, 1}
 
 
 def test_lodstone_controller_uses_model_shared_runtime():

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -348,7 +348,7 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
     tile = Tile(key, region, 0.0)
     plan = Plan((tile,), frozenset({key}), 0, (tile,))
 
-    target.prepare(None, plan)
+    lease = target.prepare(None, plan)
     window = target.resident.windows[0]
     _buffer, grid, volume = target.resources[window]
 
@@ -356,6 +356,8 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
     assert grid.matrix.shape == (4, 5, 6)
     assert grid.origin == pytest.approx((60, 50, 40))
     assert window.nbytes < np.prod(source.pyramid.levels[0].shape) * 2
+    assert lease.available_keys == frozenset()
+    assert lease.pending_keys == frozenset({key})
 
     target.apply(
         [
@@ -370,6 +372,7 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
     assert target.current_window is None
     assert grid.changed == 0
     assert volume.drawing_updates == 0
+    assert lease.available_keys == frozenset({key})
     target.phase_complete(None, plan, 0)
     _live_buffer, published_grid, published_volume = target.resources[window]
     assert target.current_window is window
@@ -384,6 +387,64 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
     assert not np.shares_memory(grid.matrix, published_grid.matrix)
     assert target.resident.active == {0: window}
     assert target._bounds_resource is None
+
+    target.apply(
+        [
+            Update(
+                key,
+                region,
+                np.full(region.shape, 2, dtype=np.uint16),
+                source.pyramid.levels[0].voxel_to_world,
+            ),
+        ],
+    )
+    assert np.all(published_grid.matrix == 1)
+    target.phase_complete(None, plan, 0)
+    _buffer, replacement_grid, replacement_volume = target.resources[window]
+
+    assert published_volume.deleted
+    assert replacement_volume.display
+    assert np.all(replacement_grid.matrix == 2)
+
+
+def test_lodstone_multichannel_back_buffers_switch_before_fronts_retire():
+    events = []
+
+    class Target:
+        def __init__(self, channel):
+            self.channel = channel
+            self._back_resources = {}
+
+        def _activate_back(self, level):
+            self._back_resources.pop(level)
+            events.append(("activate", self.channel))
+            return (None, None, f"front-{self.channel}")
+
+        def _delete_volume(self, volume):
+            events.append(("delete", volume))
+
+        def _flush_deferred_retired(self):
+            events.append(("flush", self.channel))
+
+    targets = [Target(0), Target(1)]
+    model = type("StreamingModel", (), {})()
+    model.controllers = [type("Controller", (), {"target": target})() for target in targets]
+    model.session = type(
+        "Session",
+        (),
+        {"main_view": type("MainView", (), {"redraw_needed": False})()},
+    )()
+    targets[0]._back_resources[0] = (object(), object())
+
+    LodstoneZarrModel.present_lodstone_level(model, 0)
+
+    assert events == []
+    targets[1]._back_resources[0] = (object(), object())
+
+    LodstoneZarrModel.present_lodstone_level(model, 0)
+
+    assert events[:2] == [("activate", 0), ("activate", 1)]
+    assert events[2:4] == [("delete", "front-0"), ("delete", "front-1")]
 
 
 def test_lodstone_streaming_rejects_multiple_timepoints_before_starting_streams():

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -6,10 +6,11 @@ import fsspec
 import numpy as np
 import pytest
 import zarr
-from lodstone import Plan, Region, Tile, TileKey, Update
+from lodstone import Plan, Region, ResidentWindow, Tile, TileKey, Update
 
 from src.info import NGFFFetcherInfo, OMEZarrOpenerInfo
 from src.lodstone_adapter import (
+    ChimeraXDispatcher,
     ChimeraXVolumeTarget,
     LodstoneVolumeController,
     LodstoneZarrModel,
@@ -348,18 +349,17 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
     tile = Tile(key, region, 0.0)
     plan = Plan((tile,), frozenset({key}), 0, (tile,))
 
-    lease = target.prepare(None, plan)
+    target.register_plan(plan, 1, "test")
+    prepared = target.stage_prepare(None, plan)
+    lease = target.prepare(None, plan, prepared)
     window = target.resident.windows[0]
-    _buffer, grid, volume = target.resources[window]
 
     assert window.data.shape == (1, 4, 5, 6)
-    assert grid.matrix.shape == (4, 5, 6)
-    assert grid.origin == pytest.approx((60, 50, 40))
     assert window.nbytes < np.prod(source.pyramid.levels[0].shape) * 2
     assert lease.available_keys == frozenset()
     assert lease.pending_keys == frozenset({key})
 
-    target.apply(
+    changes = target.stage(
         [
             Update(
                 key,
@@ -369,26 +369,25 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
             ),
         ],
     )
+    target.apply(changes)
     assert target.current_window is None
-    assert grid.changed == 0
-    assert volume.drawing_updates == 0
     assert lease.available_keys == frozenset({key})
-    target.phase_complete(None, plan, 0)
+    publications = target.stage_phase(None, plan, 0)
+    target.phase_complete(None, plan, 0, publications)
     _live_buffer, published_grid, published_volume = target.resources[window]
     assert target.current_window is window
-    assert volume.deleted
+    assert published_grid.matrix.shape == (4, 5, 6)
+    assert published_grid.origin == pytest.approx((60, 50, 40))
     assert published_volume.drawing_updates == 1
     assert target._bounds_resource is None
     target.complete(None, plan)
 
-    assert np.all(grid.matrix == 1)
-    assert grid.changed == 0
     assert np.all(published_grid.matrix == 1)
-    assert not np.shares_memory(grid.matrix, published_grid.matrix)
+    assert not np.shares_memory(window.data, published_grid.matrix)
     assert target.resident.active == {0: window}
     assert target._bounds_resource is None
 
-    target.apply(
+    changes = target.stage(
         [
             Update(
                 key,
@@ -398,13 +397,59 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
             ),
         ],
     )
+    target.apply(changes)
     assert np.all(published_grid.matrix == 1)
-    target.phase_complete(None, plan, 0)
+    publications = target.stage_phase(None, plan, 0)
+    target.phase_complete(None, plan, 0, publications)
     _buffer, replacement_grid, replacement_volume = target.resources[window]
 
     assert published_volume.deleted
     assert replacement_volume.display
     assert np.all(replacement_grid.matrix == 2)
+    assert any(record.operation == "snapshot_copy_and_range" and record.thread == "cpu" for record in target.timeline)
+    assert all(record.bytes_processed == 0 for record in target.timeline if record.operation == "target.apply")
+
+
+def test_lodstone_snapshot_is_immutable_and_upload_bounded():
+    target = ChimeraXVolumeTarget.__new__(ChimeraXVolumeTarget)
+    target.displayed_axes = (1, 2, 3)
+    target.max_focus_dimension = 8
+    target.snapshot_budget = 64
+    target.upload_budget = 64
+    region = Region((0, 10, 20, 30), (1, 18, 28, 38))
+    window = ResidentWindow(
+        0,
+        region,
+        np.ones(region.shape, dtype=np.uint16),
+        np.eye(5),
+    )
+
+    snapshot, bounded_region = target._bounded_snapshot(window)
+
+    assert snapshot.nbytes <= 64
+    assert not snapshot.flags.writeable
+    assert all(size <= 8 for size in snapshot.shape)
+    assert bounded_region.start != region.start
+    with pytest.raises(ValueError):
+        snapshot[...] = 2
+
+
+def test_chimerax_dispatcher_runs_one_callback_per_graphics_cycle():
+    class Triggers:
+        def add_handler(self, _name, callback):
+            self.callback = callback
+            return type("Handler", (), {"remove": lambda self: None})()
+
+    triggers = Triggers()
+    dispatcher = ChimeraXDispatcher(type("Session", (), {"triggers": triggers})())
+    calls = []
+    dispatcher(lambda: calls.append(1))
+    dispatcher(lambda: calls.append(2))
+
+    triggers.callback()
+    assert calls == [1]
+    triggers.callback()
+    assert calls == [1, 2]
 
 
 def test_lodstone_multichannel_back_buffers_switch_before_fronts_retire():
@@ -434,6 +479,8 @@ def test_lodstone_multichannel_back_buffers_switch_before_fronts_retire():
         (),
         {"main_view": type("MainView", (), {"redraw_needed": False})()},
     )()
+    queued = []
+    model.dispatcher = queued.append
     targets[0]._back_resources[0] = (object(), object())
 
     LodstoneZarrModel.present_lodstone_level(model, 0)
@@ -444,6 +491,9 @@ def test_lodstone_multichannel_back_buffers_switch_before_fronts_retire():
     LodstoneZarrModel.present_lodstone_level(model, 0)
 
     assert events[:2] == [("activate", 0), ("activate", 1)]
+    assert len(queued) == 1
+    assert len(events) == 2
+    queued.pop()()
     assert events[2:4] == [("delete", "front-0"), ("delete", "front-1")]
 
 
@@ -498,14 +548,23 @@ def test_lodstone_controller_skips_coverage_equivalent_plan_submissions():
     controller = LodstoneVolumeController.__new__(LodstoneVolumeController)
     controller.stream = StreamStub()
     controller.session = type("Session", (), {"logger": logger})()
-    controller.target = type("Target", (), {"name": "test"})()
+    controller.target = type(
+        "Target",
+        (),
+        {
+            "name": "test",
+            "register_plan": lambda *_args: None,
+        },
+    )()
+    controller.owner = type("Owner", (), {"deleted": False})()
+    controller._request_epoch = 3
     controller._target_level = None
     controller._active_coverage = None
     view = object()
 
-    controller._submit_view(view)
-    controller._submit_view(view)
-    controller._submit_view(view)
+    controller._submit_planned(view, initial, 3, "test")
+    controller._submit_planned(view, equivalent, 3, "test")
+    controller._submit_planned(view, changed, 3, "test")
 
     assert [plan for _view, plan in controller.stream.submissions] == [initial, changed]
 

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -536,7 +536,7 @@ def test_lodstone_multichannel_back_buffers_switch_before_fronts_retire():
     assert events[2:4] == [("delete", "front-0"), ("delete", "front-1")]
 
 
-def test_lodstone_streaming_rejects_multiple_timepoints_before_starting_streams():
+def test_lodstone_streaming_requires_one_selected_timepoint():
     from chimerax.core.session import Session
 
     group, _data = _make_image(
@@ -546,8 +546,20 @@ def test_lodstone_streaming_rejects_multiple_timepoints_before_starting_streams(
     )
     session = Session("OME-Zarr Lodstone time-series test", offscreen_rendering=True)
 
-    with pytest.raises(OMEZarrFormatError, match="switching timepoints"):
+    with pytest.raises(OMEZarrFormatError, match="requires one timepoint"):
         LodstoneZarrModel("time series", session, group)
+
+    model = LodstoneZarrModel("time series", session, group, time_index=1)
+    try:
+        assert {controller.target.time_index for controller in model.controllers} == {1}
+        assert {tuple(controller.index) for controller in model.controllers} == {
+            (1, None, None, None),
+        }
+    finally:
+        model.delete()
+
+    with pytest.raises(OMEZarrFormatError, match="available range 0-1"):
+        LodstoneZarrModel("time series", session, group, time_index=2)
 
 
 def test_lodstone_controller_skips_coverage_equivalent_plan_submissions():
@@ -1000,6 +1012,8 @@ def test_open_and_fetch_providers_expose_nonnegative_read_ahead_option():
 
     assert OMEZarrOpenerInfo().open_args["read_ahead"] is NonNegativeIntArg
     assert NGFFFetcherInfo().fetch_args["read_ahead"] is NonNegativeIntArg
+    assert OMEZarrOpenerInfo().open_args["time"] is NonNegativeIntArg
+    assert NGFFFetcherInfo().fetch_args["time"] is NonNegativeIntArg
 
 
 def test_wrapped_grid_rejects_noninteger_scale_and_misaligned_translation():

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -9,7 +9,7 @@ import zarr
 from lodstone import Plan, Region, Tile, TileKey, Update
 
 from src.info import NGFFFetcherInfo, OMEZarrOpenerInfo
-from src.lodstone_adapter import ChimeraXVolumeTarget, source_from_group
+from src.lodstone_adapter import ChimeraXVolumeTarget, _patch_volume_texture, source_from_group
 from src.map_data.ome_metadata import (
     OMEZarrFormatError,
     bioformats2raw_series_paths,
@@ -367,6 +367,66 @@ def test_lodstone_target_uses_offset_bounded_resident_window(monkeypatch):
     assert grid.changed == 1
     assert target.resident.active == {0: window}
     assert target._bounds_resource is None
+
+
+def test_lodstone_target_patches_initialized_scalar_texture(monkeypatch):
+    buffer = np.arange(4 * 5 * 6, dtype=np.uint16).reshape((4, 5, 6))
+    window = type("Window", (), {"region": Region((0, 10, 20, 30), (1, 14, 25, 36))})()
+    update_region = Region((0, 11, 22, 33), (1, 13, 25, 36))
+    update = type("Update", (), {"region": update_region})()
+    texture = type(
+        "Texture",
+        (),
+        {
+            "id": 7,
+            "dimension": 3,
+            "data": None,
+            "_array_shape": buffer.shape,
+            "_numpy_dtype": buffer.dtype,
+        },
+    )()
+    image = type(
+        "Image",
+        (),
+        {
+            "deleted": False,
+            "_rendering_options": type("Options", (), {"colormap_on_gpu": True})(),
+            "_blend_image": None,
+            "_p_mode": "3d",
+            "_use_3d_texture": True,
+            "_planes_3d": type("Drawing", (), {"texture": texture})(),
+        },
+    )()
+
+    class Render:
+        current = 0
+
+        def make_current(self):
+            self.current += 1
+
+    render = Render()
+    volume = type(
+        "Volume",
+        (),
+        {
+            "_image": image,
+            "session": type("Session", (), {"main_view": type("MainView", (), {"render": render})()})(),
+        },
+    )()
+    uploads = []
+    monkeypatch.setattr(
+        "src.lodstone_adapter._upload_texture_3d",
+        lambda actual_texture, data, offset: uploads.append((actual_texture, data.copy(), offset)),
+    )
+
+    patched = _patch_volume_texture(volume, buffer, window, (update,), (1, 2, 3))
+
+    assert patched
+    assert render.current == 1
+    assert len(uploads) == 1
+    assert uploads[0][0] is texture
+    assert uploads[0][2] == (1, 2, 3)
+    np.testing.assert_array_equal(uploads[0][1], buffer[1:3, 2:5, 3:6])
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])


### PR DESCRIPTION
Depends on https://github.com/kephale/lodstone/pull/1.

## Summary

- add opt-in `streaming true` OME-Zarr opening backed by Lodstone
- maintain bounded dense ChimeraX volumes with coarse-to-fine composition
- stage array writes and dtype conversion off the graphics thread
- patch initialized 3D textures by repaired region, with a safe full-volume fallback
- replan on camera changes and publish completed progressive phases
- cap planning by the renderer 3D texture limit and use a 256 MiB default GPU budget
- stop stream resources cleanly when models close or construction fails
- document a reproducible interactive test against the EBI IDR store

Streaming is intentionally limited to image groups for this first integration. Explicit scale selection, associated labels, and time series continue through the existing non-streaming path. Multi-timepoint streaming is rejected before any stream starts.

The Lodstone dependency is pinned to the exact PR commit until that API is merged and released.

## Validation

- `ruff check src tests`
- portable suite: 16 passed, 11 skipped, 3 deselected
- native ChimeraX suite: 69 passed (9 existing model teardown warnings)
- `devel build .` succeeds and produces the ChimeraX wheel

The locally installed ChimeraX Daily is 1.13.dev202608021548, older than the declared minimum 1.13.dev202608172052. A no-dependency development install was used to exercise native tests and bundle construction; supported interactive validation requires an updated Daily.

## Interactive test

Build and install using the commands in `CONTRIBUTING.md`, launch ChimeraX, then run:

```
open ngff:https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr streaming true
```

Rotate and zoom to verify coarse data stays visible while fine chunks replace it, then close the top-level image model and check that no delayed callback errors appear.