### PR TITLE
chore: update Lodstone to 0.1.0a1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Daily:
 ```bash
 export CHIMERAX_PYTHON=/Applications/ChimeraX_Daily.app/Contents/bin/python3.14
 "$CHIMERAX_PYTHON" -m pip install --no-deps --force-reinstall \
-  lodstone==0.1.0a0
+  lodstone==0.1.0a1
 PYTHONPATH="$PWD" "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit \
   --cmd "devel build ."
 "$CHIMERAX_PYTHON" -m chimerax.core --nogui --exit --cmd \

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ open ngff:s3://bucket-name/path/to/file.zarr scales 1,2
 
 ```bash
 /Applications/ChimeraX_Daily.app/Contents/bin/pip install \
-  lodstone==0.1.0a0
+  lodstone==0.1.0a1
 ```
 
 ```chimerax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/uermel/chimerax-ome-zarr/issues"
 
 [project.optional-dependencies]
 streaming = [
-    "lodstone==0.1.0a0",
+    "lodstone==0.1.0a1",
 ]
 dev = [
     "black",

--- a/src/lodstone_adapter.py
+++ b/src/lodstone_adapter.py
@@ -257,6 +257,7 @@ class ChimeraXVolumeTarget:
             # Translucent volumes benefit from a camera-centered column of
             # detail before spending the entire focus budget on a near slab.
             focus_depth_weight=0.5,
+            focus_depth_target=0.5,
         )
 
     def register_plan(self, plan, request_epoch: int, reason: str) -> None:

--- a/tests/chimerax/test_ome_zarr.py
+++ b/tests/chimerax/test_ome_zarr.py
@@ -528,6 +528,7 @@ def test_lodstone_target_keeps_coarse_context_and_user_contrast(monkeypatch):
     )
     assert target.layout(None, source.pyramid).mixed_lod
     assert target.layout(None, source.pyramid).focus_depth_weight == 0.5
+    assert target.layout(None, source.pyramid).focus_depth_target == 0.5
 
     selection = (0, -1, -1, -1)
     coarse_key = TileKey(1, (0, 0, 0), selection)


### PR DESCRIPTION
## Summary

- update the streaming dependency to Lodstone 0.1.0a1
- use depth-centered focus ordering for translucent volumes
- refresh installation documentation

## Validation

- portable: 16 passed, 11 skipped
- native ChimeraX: 77 passed
- Ruff and Black pass
- `devel build .` succeeds